### PR TITLE
feat: Add the Marketing Banner component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0-development",
       "license": "Apache-2.0",
       "dependencies": {
+        "@contentful/rich-text-react-renderer": "^16.0.1",
         "@dcl/schemas": "^13.9.0",
         "@dcl/ui-env": "^1.5.1",
         "@emotion/react": "^11.11.4",
@@ -27,6 +28,7 @@
         "@babel/preset-env": "^7.24.7",
         "@babel/preset-react": "^7.24.7",
         "@babel/preset-typescript": "^7.24.7",
+        "@contentful/rich-text-types": "^17.0.0",
         "@dcl/eslint-config": "^2.2.1",
         "@storybook/addon-docs": "^7.6.20",
         "@storybook/addon-essentials": "^7.6.20",
@@ -2220,6 +2222,32 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@contentful/rich-text-react-renderer": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-react-renderer/-/rich-text-react-renderer-16.0.1.tgz",
+      "integrity": "sha512-7wZZBMgwbq5Udp2KebKCJoh9K+EPGlgRkudhXSp+OxtAIdBC6JUz3Oi9kXXKYKLeSg7iTBpkO1dd0/xFjHHKbg==",
+      "dependencies": {
+        "@contentful/rich-text-types": "^17.0.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.6 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.6 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@contentful/rich-text-types": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-17.0.0.tgz",
+      "integrity": "sha512-x50t6sILzFHBdFpAo0foJRnH8fHWyidheWhAv3uwt9aOnNqTh893gxyoc3Q0RVEZxXfHpTi+O9gmakHcdlRdTA==",
+      "dependencies": {
+        "is-plain-obj": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -13023,6 +13051,17 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
+      "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-plain-object": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "homepage": "https://github.com/decentraland/ui2#readme",
   "dependencies": {
+    "@contentful/rich-text-react-renderer": "^16.0.1",
     "@dcl/schemas": "^13.9.0",
     "@dcl/ui-env": "^1.5.1",
     "@emotion/react": "^11.11.4",
@@ -55,6 +56,7 @@
     "@babel/preset-env": "^7.24.7",
     "@babel/preset-react": "^7.24.7",
     "@babel/preset-typescript": "^7.24.7",
+    "@contentful/rich-text-types": "^17.0.0",
     "@dcl/eslint-config": "^2.2.1",
     "@storybook/addon-docs": "^7.6.20",
     "@storybook/addon-essentials": "^7.6.20",

--- a/src/components/MarketingBanner/MarketingBanner.stories.tsx
+++ b/src/components/MarketingBanner/MarketingBanner.stories.tsx
@@ -1,0 +1,41 @@
+import { MarketingBanner } from "./MarketingBanner"
+import { Locales } from "../../hooks/contenful"
+import type { Meta, StoryObj } from "@storybook/react"
+
+const meta = {
+  title: "Decentraland UI/MarketingBanner",
+  component: MarketingBanner,
+  parameters: {
+    layout: "fullscreen",
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof MarketingBanner>
+
+type Story = StoryObj<typeof MarketingBanner>
+
+const Default: Story = {
+  args: {
+    id: "2maJ4UuoqaYtbZxVGymsJo",
+    environment: "development",
+    token: "AATjg5ZJgxllQW8PBSQV4ZaY5wh9W_lQSKIiERHY-sc",
+    space: "ea2ybdmmn1kv",
+  },
+}
+
+const SpanishLocale: Story = {
+  args: {
+    ...Default.args,
+    locale: Locales.es,
+  },
+}
+
+const ChineseLocale: Story = {
+  args: {
+    ...Default.args,
+    locale: Locales.zh,
+  },
+}
+
+export { Default, SpanishLocale, ChineseLocale }
+// eslint-disable-next-line import/no-default-export
+export default meta

--- a/src/components/MarketingBanner/MarketingBanner.styled.ts
+++ b/src/components/MarketingBanner/MarketingBanner.styled.ts
@@ -1,0 +1,142 @@
+import styled from "@emotion/styled"
+import { Box, Button as MuiButton, Typography } from "@mui/material"
+import type { Property } from "csstype"
+
+const convertAlignmentToFlex = (alignment: Property.TextAlign) => {
+  switch (alignment) {
+    case "left":
+      return "flex-start"
+    case "center":
+      return "center"
+    case "right":
+      return "flex-end"
+    default:
+      return "flex-start"
+  }
+}
+
+const LoadingContainer = styled(Box)({
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+  width: "100%",
+})
+
+const BannerContainer = styled(Box, {
+  shouldForwardProp: (prop) =>
+    prop !== "mobileBackground" && prop !== "fullSizeBackground",
+})<{
+  mobileBackground: string
+  fullSizeBackground: string
+}>(({ mobileBackground, fullSizeBackground }) => ({
+  width: "100%",
+  overflow: "hidden",
+  display: "flex",
+  padding: "2rem",
+  flexDirection: "column-reverse",
+  justifyContent: "space-between",
+  backgroundImage: `url(${mobileBackground})`,
+  backgroundSize: "cover",
+  backgroundPosition: "center",
+  alignItems: "center",
+  "@media (min-width: 768px)": {
+    flexDirection: "row",
+    backgroundImage: `url(${fullSizeBackground})`,
+  },
+}))
+
+const ContentWrapper = styled(Box)({
+  display: "flex",
+  flexDirection: "row",
+  flexGrow: 1,
+  marginRight: "20px",
+})
+
+const Content = styled(Box)({
+  display: "flex",
+  flexDirection: "column",
+  gap: "0.1rem",
+  "@media (max-width: 767px)": {
+    padding: "1rem",
+  },
+})
+
+const Logo = styled("img")({
+  flexShrink: 0,
+  maxWidth: "400px",
+  "@media (max-width: 767px)": {
+    maxWidth: "300px",
+    marginBottom: "1rem",
+  },
+})
+
+const Title = styled(Typography, {
+  shouldForwardProp: (prop) =>
+    prop !== "mobileTitleAlignment" && prop !== "desktopTitleAlignment",
+})<{
+  mobileTitleAlignment?: Property.TextAlign
+  desktopTitleAlignment?: Property.TextAlign
+}>(({ mobileTitleAlignment, desktopTitleAlignment }) => ({
+  margin: 0,
+  color: "#fff",
+  textAlign: desktopTitleAlignment || "left",
+  fontSize: "28px",
+  textTransform: "uppercase",
+  fontWeight: 800,
+  "@media (max-width: 767px)": {
+    textAlign: mobileTitleAlignment || "left",
+    fontSize: "24px",
+  },
+}))
+
+const Text = styled(Box, {
+  shouldForwardProp: (prop) =>
+    prop !== "mobileTextAlignment" && prop !== "desktopTextAlignment",
+})<{
+  mobileTextAlignment?: Property.TextAlign
+  desktopTextAlignment?: Property.TextAlign
+}>(({ mobileTextAlignment, desktopTextAlignment }) => ({
+  color: "#fff",
+  textAlign: desktopTextAlignment || "left",
+  fontSize: "19px",
+  "& p": {
+    margin: 0,
+    padding: 0,
+  },
+  "@media (max-width: 767px)": {
+    textAlign: mobileTextAlignment || "left",
+    fontSize: "16px",
+  },
+}))
+
+const ButtonContainer = styled(Box, {
+  shouldForwardProp: (prop) =>
+    prop !== "mobileAlignment" && prop !== "desktopAlignment",
+})<{
+  mobileAlignment?: Property.TextAlign
+  desktopAlignment?: Property.TextAlign
+}>(({ mobileAlignment, desktopAlignment }) => ({
+  display: "flex",
+  marginTop: "1rem",
+  alignItems: convertAlignmentToFlex(desktopAlignment || "left"),
+  "@media (max-width: 767px)": {
+    alignItems: convertAlignmentToFlex(mobileAlignment || "left"),
+  },
+}))
+
+const Button = styled(MuiButton)({
+  textTransform: "uppercase",
+  minWidth: "300px",
+})
+
+export {
+  LoadingContainer,
+  BannerContainer,
+  Content,
+  ContentWrapper,
+  Logo,
+  Title,
+  Text,
+  ButtonContainer,
+  Button,
+}

--- a/src/components/MarketingBanner/MarketingBanner.styled.ts
+++ b/src/components/MarketingBanner/MarketingBanner.styled.ts
@@ -28,22 +28,26 @@ const BannerContainer = styled(Box, {
 })<{
   mobileBackground: string
   fullSizeBackground: string
-}>(({ mobileBackground, fullSizeBackground }) => ({
-  width: "100%",
-  overflow: "hidden",
-  display: "flex",
-  padding: "2rem",
-  flexDirection: "column-reverse",
-  justifyContent: "space-between",
-  backgroundImage: `url(${mobileBackground})`,
-  backgroundSize: "cover",
-  backgroundPosition: "center",
-  alignItems: "center",
-  "@media (min-width: 768px)": {
+}>((props) => {
+  const { theme, mobileBackground, fullSizeBackground } = props
+
+  return {
+    width: "100%",
+    overflow: "hidden",
+    display: "flex",
+    padding: "2rem",
+    justifyContent: "space-between",
     flexDirection: "row",
     backgroundImage: `url(${fullSizeBackground})`,
-  },
-}))
+    backgroundSize: "cover",
+    backgroundPosition: "center",
+    alignItems: "center",
+    [theme.breakpoints.down("sm")]: {
+      backgroundImage: `url(${mobileBackground})`,
+      flexDirection: "column-reverse",
+    },
+  }
+})
 
 const ContentWrapper = styled(Box)({
   display: "flex",
@@ -52,22 +56,30 @@ const ContentWrapper = styled(Box)({
   marginRight: "20px",
 })
 
-const Content = styled(Box)({
-  display: "flex",
-  flexDirection: "column",
-  gap: "0.1rem",
-  "@media (max-width: 767px)": {
-    padding: "1rem",
-  },
+const Content = styled(Box)((props) => {
+  const { theme } = props
+
+  return {
+    display: "flex",
+    flexDirection: "column",
+    gap: "0.1rem",
+    [theme.breakpoints.down("sm")]: {
+      padding: "1rem",
+    },
+  }
 })
 
-const Logo = styled("img")({
-  flexShrink: 0,
-  maxWidth: "400px",
-  "@media (max-width: 767px)": {
-    maxWidth: "300px",
-    marginBottom: "1rem",
-  },
+const Logo = styled("img")((props) => {
+  const { theme } = props
+
+  return {
+    flexShrink: 0,
+    maxWidth: "400px",
+    [theme.breakpoints.down("sm")]: {
+      maxWidth: "300px",
+      marginBottom: "1rem",
+    },
+  }
 })
 
 const Title = styled(Typography, {
@@ -76,18 +88,22 @@ const Title = styled(Typography, {
 })<{
   mobileTitleAlignment?: Property.TextAlign
   desktopTitleAlignment?: Property.TextAlign
-}>(({ mobileTitleAlignment, desktopTitleAlignment }) => ({
-  margin: 0,
-  color: "#fff",
-  textAlign: desktopTitleAlignment || "left",
-  fontSize: "28px",
-  textTransform: "uppercase",
-  fontWeight: 800,
-  "@media (max-width: 767px)": {
-    textAlign: mobileTitleAlignment || "left",
-    fontSize: "24px",
-  },
-}))
+}>((props) => {
+  const { theme, mobileTitleAlignment, desktopTitleAlignment } = props
+
+  return {
+    margin: 0,
+    color: "#fff",
+    textAlign: desktopTitleAlignment || "left",
+    fontSize: "28px",
+    textTransform: "uppercase",
+    fontWeight: 800,
+    [theme.breakpoints.down("sm")]: {
+      textAlign: mobileTitleAlignment || "left",
+      fontSize: "24px",
+    },
+  }
+})
 
 const Text = styled(Box, {
   shouldForwardProp: (prop) =>
@@ -95,19 +111,23 @@ const Text = styled(Box, {
 })<{
   mobileTextAlignment?: Property.TextAlign
   desktopTextAlignment?: Property.TextAlign
-}>(({ mobileTextAlignment, desktopTextAlignment }) => ({
-  color: "#fff",
-  textAlign: desktopTextAlignment || "left",
-  fontSize: "19px",
-  "& p": {
-    margin: 0,
-    padding: 0,
-  },
-  "@media (max-width: 767px)": {
-    textAlign: mobileTextAlignment || "left",
-    fontSize: "16px",
-  },
-}))
+}>((props) => {
+  const { theme, mobileTextAlignment, desktopTextAlignment } = props
+
+  return {
+    color: "#fff",
+    textAlign: desktopTextAlignment || "left",
+    fontSize: "19px",
+    "& p": {
+      margin: 0,
+      padding: 0,
+    },
+    [theme.breakpoints.down("sm")]: {
+      textAlign: mobileTextAlignment || "left",
+      fontSize: "16px",
+    },
+  }
+})
 
 const ButtonContainer = styled(Box, {
   shouldForwardProp: (prop) =>
@@ -115,14 +135,18 @@ const ButtonContainer = styled(Box, {
 })<{
   mobileAlignment?: Property.TextAlign
   desktopAlignment?: Property.TextAlign
-}>(({ mobileAlignment, desktopAlignment }) => ({
-  display: "flex",
-  marginTop: "1rem",
-  alignItems: convertAlignmentToFlex(desktopAlignment || "left"),
-  "@media (max-width: 767px)": {
-    alignItems: convertAlignmentToFlex(mobileAlignment || "left"),
-  },
-}))
+}>((props) => {
+  const { theme, mobileAlignment, desktopAlignment } = props
+
+  return {
+    display: "flex",
+    marginTop: "1rem",
+    alignItems: convertAlignmentToFlex(desktopAlignment || "left"),
+    [theme.breakpoints.down("sm")]: {
+      alignItems: convertAlignmentToFlex(mobileAlignment || "left"),
+    },
+  }
+})
 
 const Button = styled(MuiButton)({
   textTransform: "uppercase",

--- a/src/components/MarketingBanner/MarketingBanner.tsx
+++ b/src/components/MarketingBanner/MarketingBanner.tsx
@@ -1,0 +1,128 @@
+import React from "react"
+import { documentToReactComponents } from "@contentful/rich-text-react-renderer"
+import CircularProgress from "@mui/material/CircularProgress"
+import {
+  Locales,
+  getAssetUrl,
+  useGetContentfulEntry,
+} from "../../hooks/contenful"
+import {
+  IBannerFields,
+  LowercasedAlignment,
+  MarketingBannerProps,
+} from "./MarketingBanner.types"
+import {
+  BannerContainer,
+  Button,
+  ButtonContainer,
+  Content,
+  LoadingContainer,
+  Logo,
+  Text,
+  Title,
+} from "./MarketingBanner.styled"
+
+export const MarketingBanner: React.FC<MarketingBannerProps> = ({
+  id,
+  environment,
+  token,
+  space,
+  locale = Locales.enUS,
+}) => {
+  const { fields, assets, isLoading, error } =
+    useGetContentfulEntry<IBannerFields>(id, environment, token, space)
+
+  if (isLoading) {
+    return (
+      <LoadingContainer>
+        <CircularProgress />
+      </LoadingContainer>
+    )
+  }
+
+  // If there is no banner fields or the banner is not supposed to be shown, return null
+  if (!fields || !fields.showBanner[locale] || error) {
+    return null
+  }
+
+  return (
+    <BannerContainer
+      mobileBackground={getAssetUrl(
+        assets,
+        locale,
+        fields.mobileBackground[locale]
+      )}
+      fullSizeBackground={getAssetUrl(
+        assets,
+        locale,
+        fields.fullSizeBackground[locale]
+      )}
+    >
+      <Content>
+        <Title
+          variant="h1"
+          mobileTitleAlignment={
+            fields.mobileTitleAlignment[
+              locale
+            ]?.toLowerCase() as LowercasedAlignment
+          }
+          desktopTitleAlignment={
+            fields.desktopTitleAlignment[
+              locale
+            ]?.toLowerCase() as LowercasedAlignment
+          }
+        >
+          {fields.title[locale]}
+        </Title>
+
+        <Text
+          desktopTextAlignment={
+            fields.desktopTextAlignment[
+              locale
+            ]?.toLowerCase() as LowercasedAlignment
+          }
+          mobileTextAlignment={
+            fields.mobileTextAlignment[
+              locale
+            ]?.toLowerCase() as LowercasedAlignment
+          }
+        >
+          {fields.text[locale]
+            ? documentToReactComponents(fields.text[locale])
+            : null}
+        </Text>
+
+        {fields.showButton[locale] &&
+        fields.buttonLink?.[locale] &&
+        fields.buttonsText?.[locale] ? (
+          <ButtonContainer
+            desktopAlignment={
+              fields.desktopButtonAlignment[
+                locale
+              ]?.toLowerCase() as LowercasedAlignment
+            }
+            mobileAlignment={
+              fields.mobileButtonAlignment[
+                locale
+              ]?.toLowerCase() as LowercasedAlignment
+            }
+          >
+            <Button
+              href={fields.buttonLink[locale]}
+              variant="contained"
+              disableElevation
+            >
+              {fields.buttonsText[locale]}
+            </Button>
+          </ButtonContainer>
+        ) : null}
+      </Content>
+      {fields.logo && fields.logo[locale] && (
+        <Logo
+          src={getAssetUrl(assets, locale, fields.logo[locale])}
+          alt="Banner logo"
+        />
+      )}
+    </BannerContainer>
+  )
+}

--- a/src/components/MarketingBanner/MarketingBanner.tsx
+++ b/src/components/MarketingBanner/MarketingBanner.tsx
@@ -22,15 +22,20 @@ import {
   Title,
 } from "./MarketingBanner.styled"
 
-export const MarketingBanner: React.FC<MarketingBannerProps> = ({
-  id,
-  environment,
-  token,
-  space,
-  locale = Locales.enUS,
-}) => {
+const BANNER_CONTENT_TYPE = "banner"
+
+export const MarketingBanner: React.FC<MarketingBannerProps> = (
+  props: MarketingBannerProps
+) => {
+  const { id, environment, token, space, locale = Locales.enUS } = props
   const { fields, assets, isLoading, error } =
-    useGetContentfulEntry<IBannerFields>(id, environment, token, space)
+    useGetContentfulEntry<IBannerFields>(
+      id,
+      environment,
+      BANNER_CONTENT_TYPE,
+      token,
+      space
+    )
 
   if (isLoading) {
     return (

--- a/src/components/MarketingBanner/MarketingBanner.types.ts
+++ b/src/components/MarketingBanner/MarketingBanner.types.ts
@@ -1,0 +1,38 @@
+import {
+  AlignmentFieldType,
+  Locales,
+  LocalizedField,
+  SysAssetLink,
+} from "hooks/contenful"
+import type { Document } from "@contentful/rich-text-types"
+
+type LowercasedAlignment = "left" | "center" | "right"
+
+type IBannerFields = {
+  id: LocalizedField<string>
+  showBanner: LocalizedField<boolean>
+  title: LocalizedField<string>
+  mobileTitleAlignment: LocalizedField<AlignmentFieldType>
+  desktopTitleAlignment: LocalizedField<AlignmentFieldType>
+  text: LocalizedField<Document>
+  desktopTextAlignment: LocalizedField<AlignmentFieldType>
+  mobileTextAlignment: LocalizedField<AlignmentFieldType>
+  showButton: LocalizedField<boolean>
+  buttonLink?: LocalizedField<string>
+  buttonsText?: LocalizedField<string>
+  desktopButtonAlignment: LocalizedField<AlignmentFieldType>
+  mobileButtonAlignment: LocalizedField<AlignmentFieldType>
+  fullSizeBackground: LocalizedField<SysAssetLink>
+  mobileBackground: LocalizedField<SysAssetLink>
+  logo?: LocalizedField<SysAssetLink>
+}
+
+type MarketingBannerProps = {
+  id: string
+  environment: string
+  token: string
+  space: string
+  locale?: Locales
+}
+
+export type { LowercasedAlignment, IBannerFields, MarketingBannerProps }

--- a/src/components/MarketingBanner/index.ts
+++ b/src/components/MarketingBanner/index.ts
@@ -1,0 +1,2 @@
+export { MarketingBanner } from "./MarketingBanner"
+export { MarketingBannerProps } from "./MarketingBanner.types"

--- a/src/hooks/contenful/contentful.ts
+++ b/src/hooks/contenful/contentful.ts
@@ -57,13 +57,13 @@ const useGetContentfulEntry = <
         )
 
         if (!response.ok) {
-          throw new Error("Failed to fetch banner data")
+          throw new Error("Failed to fetch entity data")
         }
 
         const data: ContentfulResponse<T> = await response.json()
 
         if (!data.items || data.items.length === 0) {
-          throw new Error("No banner found with the specified ID")
+          throw new Error("No entity found with the specified ID")
         }
 
         const assetsMap = data.includes.Asset.reduce(

--- a/src/hooks/contenful/contentful.ts
+++ b/src/hooks/contenful/contentful.ts
@@ -1,0 +1,91 @@
+import { useEffect, useState } from "react"
+import {
+  ContentfulAsset,
+  ContentfulResponse,
+  Locales,
+  LocalizedField,
+  LocalizedFieldType,
+  SysAssetLink,
+} from "./contentful.types"
+
+const getAssetUrl = (
+  assets: Record<string, ContentfulAsset>,
+  locale: Locales,
+  assetLink?: SysAssetLink
+): string => {
+  if (!assetLink) return ""
+  const asset = assets[assetLink.sys.id]
+  return asset?.fields.file[locale]?.url
+    ? `https:${asset.fields.file[locale].url}`
+    : ""
+}
+
+const useGetContentfulEntry = <
+  T extends Record<string, LocalizedField<LocalizedFieldType>>,
+>(
+  id: string,
+  environment: string,
+  token: string,
+  space: string
+): {
+  fields: T | null
+  assets: {}
+  isLoading: boolean
+  error: string | null
+} => {
+  const [fields, setFields] = useState<T | null>(null)
+  const [assets, setAssets] = useState<Record<string, ContentfulAsset>>({})
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const response = await fetch(
+          `https://cdn.contentful.com/spaces/${space}/environments/${environment}/entries/?` +
+            new URLSearchParams({
+              "sys.id": id,
+              content_type: "banner",
+              locale: "*",
+            }),
+          {
+            headers: {
+              Authorization: `Bearer ${token}`,
+            },
+          }
+        )
+
+        if (!response.ok) {
+          throw new Error("Failed to fetch banner data")
+        }
+
+        const data: ContentfulResponse<T> = await response.json()
+
+        if (!data.items || data.items.length === 0) {
+          throw new Error("No banner found with the specified ID")
+        }
+
+        const assetsMap = data.includes.Asset.reduce(
+          (acc, asset) => {
+            acc[asset.sys.id] = asset
+            return acc
+          },
+          {} as Record<string, ContentfulAsset>
+        )
+
+        setAssets(assetsMap)
+        setFields(data.items[0].fields)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "An error occurred")
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    fetchData()
+  }, [id, environment, token, space])
+
+  return { fields, assets, isLoading, error }
+}
+
+export { useGetContentfulEntry, getAssetUrl }

--- a/src/hooks/contenful/contentful.ts
+++ b/src/hooks/contenful/contentful.ts
@@ -25,6 +25,7 @@ const useGetContentfulEntry = <
 >(
   id: string,
   environment: string,
+  contentType: string,
   token: string,
   space: string
 ): {
@@ -45,7 +46,7 @@ const useGetContentfulEntry = <
           `https://cdn.contentful.com/spaces/${space}/environments/${environment}/entries/?` +
             new URLSearchParams({
               "sys.id": id,
-              content_type: "banner",
+              content_type: contentType,
               locale: "*",
             }),
           {

--- a/src/hooks/contenful/contentful.types.ts
+++ b/src/hooks/contenful/contentful.types.ts
@@ -1,0 +1,75 @@
+import type { Document } from "@contentful/rich-text-types"
+
+enum ContentfulLocale {
+  enUS = "en-US",
+  es = "es",
+  zh = "zh",
+}
+
+type LocalizedField<T> = {
+  [key in ContentfulLocale]: T
+}
+
+type SysAssetLink = {
+  sys: {
+    type: "Link"
+    linkType: "Asset"
+    id: string
+  }
+}
+
+type ContentfulAsset = {
+  sys: {
+    id: string
+    type: "Asset"
+  }
+  fields: {
+    title: LocalizedField<string>
+    description: LocalizedField<string>
+    file: LocalizedField<{
+      url: string
+      details: {
+        size: number
+        image?: {
+          width: number
+          height: number
+        }
+      }
+      fileName: string
+      contentType: string
+    }>
+  }
+}
+
+type AlignmentFieldType = "Left" | "Center" | "Right"
+type LocalizedFieldType =
+  | string
+  | boolean
+  | Document
+  | SysAssetLink
+  | AlignmentFieldType
+
+type ContentfulResponse<
+  T extends Record<string, LocalizedField<LocalizedFieldType>>,
+> = {
+  items: Array<{
+    fields: T
+    sys: {
+      id: string
+      type: "Entry"
+    }
+  }>
+  includes: {
+    Asset: ContentfulAsset[]
+  }
+}
+
+export {
+  ContentfulLocale as Locales,
+  LocalizedField,
+  SysAssetLink,
+  ContentfulAsset,
+  AlignmentFieldType,
+  LocalizedFieldType,
+  ContentfulResponse,
+}

--- a/src/hooks/contenful/index.ts
+++ b/src/hooks/contenful/index.ts
@@ -1,0 +1,2 @@
+export * from "./contentful.types"
+export * from "./contentful"


### PR DESCRIPTION
This PR creates a new component, the MarketingBanner, used to show via Contentful a banner based on its entity id.
It also adds a hook to retrieve information from a Contentful entity that can be used for other purposes.