### PR TITLE
fix: Wrongly propagated props on MenuItemContainer

### DIFF
--- a/src/components/Navbar/SubMenu/SubMenu.styled.ts
+++ b/src/components/Navbar/SubMenu/SubMenu.styled.ts
@@ -24,7 +24,10 @@ const SubMenuContainer = styled(Box)((props) => {
   }
 })
 
-const MenuItemContainer = styled(Box)<MenuItemContainerProps>((props) => {
+const MenuItemContainer = styled(Box, {
+  shouldForwardProp: (prop) =>
+    !["active", "section", "isMobile"].includes(prop),
+})<MenuItemContainerProps>((props) => {
   const { active, section, theme } = props
   let modifiedStyles
   let mobileModifiedStyles


### PR DESCRIPTION
This PR removes the propagation of props that don't belong to the CSS to the HTML component.