### PR TITLE
feat: Add the new prop cdnLinks for the Download Button

### DIFF
--- a/src/components/DownloadButton/DownloadButton.tsx
+++ b/src/components/DownloadButton/DownloadButton.tsx
@@ -29,6 +29,7 @@ const DownloadButton = React.memo((props: DownloadButtonProps) => {
     href,
     startIcon,
     endIcon,
+    cdnLinks,
   } = props
 
   const [isLoadingUserAgentData, userAgentData] = useAdvancedUserAgentData()
@@ -46,7 +47,8 @@ const DownloadButton = React.memo((props: DownloadButtonProps) => {
     }
   }, [userAgentData, os])
 
-  const links = getCDNRelease(CDNSource.LAUNCHER)
+  const defaultLinks = getCDNRelease(CDNSource.LAUNCHER)
+  const links = cdnLinks || defaultLinks
 
   const defaultDownloadOption: DownloadOption | null = useMemo(() => {
     if (

--- a/src/components/DownloadButton/DownloadButton.types.ts
+++ b/src/components/DownloadButton/DownloadButton.types.ts
@@ -19,6 +19,7 @@ type DownloadButtonProps = {
   startIcon?: React.ReactNode
   endIcon?: React.ReactNode
   trackingId?: string
+  cdnLinks?: Record<string, Record<string, string>>
 }
 
 export type { DownloadButtonProps, DownloadOption }

--- a/src/components/UserMenu/UserMenu.tsx
+++ b/src/components/UserMenu/UserMenu.tsx
@@ -22,6 +22,7 @@ const UserMenu = React.memo((props: UserMenuProps) => {
     manaBalances,
     i18n = i18nUserMenu,
     hideDownloadButton,
+    cdnLinks,
     onClickSignIn,
     onClickBalance,
     onClickOpen,
@@ -131,6 +132,7 @@ const UserMenu = React.memo((props: UserMenuProps) => {
               label={i18n.download}
               onClick={onClickUserMenuItem}
               trackingId={trackingId}
+              cdnLinks={cdnLinks}
             />
           )}
         </>

--- a/src/components/UserMenu/UserMenu.types.ts
+++ b/src/components/UserMenu/UserMenu.types.ts
@@ -25,6 +25,7 @@ type UserMenuProps = Omit<
   isActivity?: boolean
   i18n?: UserMenuI18N
   hideDownloadButton?: boolean
+  cdnLinks?: Record<string, Record<string, string>>
   onClickSignIn?: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void
   onClickOpen?: (
     event: React.MouseEvent<HTMLElement, MouseEvent>,


### PR DESCRIPTION
This PR adds a new prop `cdnLinks` for the Download Button component.

This will allow us to pass custom releases dynamically without requiring us to update the lib each time.