### PR TITLE
feat: Avoid opening new tab after direct download

### DIFF
--- a/src/components/DownloadButton/DownloadButton.stories.tsx
+++ b/src/components/DownloadButton/DownloadButton.stories.tsx
@@ -84,6 +84,25 @@ const WithOS: Story = {
   ),
 }
 
+const WithCustomFallback: Story = {
+  name: "With Custom Fallback",
+  args: {
+    label: "Download with Fallback",
+    onClick: (event, options) => {
+      console.log("Custom fallback triggered:", event, options)
+      window.open("https://decentraland.org/download", "_blank")
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Button with custom handler - will try direct download first, then call custom handler if direct download not possible",
+      },
+    },
+  },
+}
+
 // eslint-disable-next-line import/no-default-export
 export default meta
-export { Basic, WithOS }
+export { Basic, WithOS, WithCustomFallback }

--- a/src/components/DownloadButton/DownloadButton.tsx
+++ b/src/components/DownloadButton/DownloadButton.tsx
@@ -89,8 +89,6 @@ const DownloadButton = React.memo((props: DownloadButtonProps) => {
     (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
       event.preventDefault()
 
-      console.log("handleClick", onClick)
-
       // If we have user agent data and a download option, try direct download
       if (userAgentData && defaultDownloadOption) {
         const redirectUrl = updateUrlWithLastValue(

--- a/src/components/Modal/DownloadModal/DownloadModal.stories.tsx
+++ b/src/components/Modal/DownloadModal/DownloadModal.stories.tsx
@@ -123,7 +123,24 @@ const WithActions: Story = {
   },
 }
 
+const DirectDownload: Story = {
+  args: {
+    ...Default.args,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Modal without custom handler - will try direct download first, fallback to default download page if not possible",
+      },
+    },
+  },
+  render: (args) => {
+    return <DownloadModal {...args} />
+  },
+}
+
 // eslint-disable-next-line import/no-default-export
 export default meta
 
-export { Default, CustomContent, WithActions }
+export { Default, CustomContent, WithActions, DirectDownload }


### PR DESCRIPTION
When users click `Jump In` without the client installed, the modal previously opened a new tab to the download page and also triggered a direct download. This created a confusing user experience.

The `DownloadButton` has now been updated to prioritize direct downloads first. If a direct download isn’t available, it will then redirect the user to the custom handler (download page).