### PR TITLE
feat: add hoverEffect prop to EventCard

### DIFF
--- a/src/components/EventCard/EventCard.stories.tsx
+++ b/src/components/EventCard/EventCard.stories.tsx
@@ -98,6 +98,36 @@ const Default: Story = {
   )
 }
 
+const CoinHover: Story = {
+  render: () => (
+    <StoryRow>
+      <EventCard
+        image={sceneThumbnail}
+        sceneName="Coin Hover (default)"
+        avatar={exampleAvatar}
+        withShadow
+        hoverEffect="coin"
+        leftBadge={
+          <BadgeGroup>
+            <LiveBadge />
+            <UserCountBadge count={24} />
+          </BadgeGroup>
+        }
+        leftBadgeTransparent
+      />
+      <EventCard
+        image={sceneThumbnail}
+        sceneName="Another Coin Card"
+        avatar={exampleAvatar}
+        withShadow
+        hoverEffect="coin"
+        leftBadge={<UserCountBadge count={12} />}
+        leftBadgeTransparent
+      />
+    </StoryRow>
+  )
+}
+
 const WithRedirectToAuth: Story = {
   render: () => (
     <EventCard
@@ -114,83 +144,6 @@ const WithRedirectToAuth: Story = {
       leftBadgeTransparent
       redirectToAuth
     />
-  )
-}
-
-const OneCard: Story = {
-  render: () => (
-    <StoryRow>
-      <EventCard
-        image={sceneThumbnail}
-        sceneName="Single Event Card"
-        avatar={exampleAvatar}
-        withShadow
-        leftBadge={
-          <BadgeGroup>
-            <LiveBadge />
-            <UserCountBadge count={24} />
-          </BadgeGroup>
-        }
-        leftBadgeTransparent
-      />
-    </StoryRow>
-  )
-}
-
-const TwoCards: Story = {
-  render: () => (
-    <StoryRow>
-      <EventCard
-        image={sceneThumbnail}
-        sceneName="Live Music Festival"
-        avatar={exampleAvatar}
-        withShadow
-        leftBadge={
-          <BadgeGroup>
-            <LiveBadge />
-            <UserCountBadge count={24} />
-          </BadgeGroup>
-        }
-        leftBadgeTransparent
-      />
-      <EventCard
-        image={sceneThumbnail}
-        sceneName="Art Gallery Opening"
-        avatar={exampleAvatar}
-        withShadow
-        leftBadge={<UserCountBadge count={12} />}
-        leftBadgeTransparent
-      />
-    </StoryRow>
-  )
-}
-
-const ThreeCards: Story = {
-  render: () => (
-    <StoryRow>
-      <EventCard
-        image={sceneThumbnail}
-        sceneName="Live Music Festival"
-        avatar={exampleAvatar}
-        withShadow
-        leftBadge={
-          <BadgeGroup>
-            <LiveBadge />
-            <UserCountBadge count={24} />
-          </BadgeGroup>
-        }
-        leftBadgeTransparent
-      />
-      <EventCard
-        image={sceneThumbnail}
-        sceneName="Art Gallery Opening"
-        avatar={exampleAvatar}
-        withShadow
-        leftBadge={<UserCountBadge count={12} />}
-        leftBadgeTransparent
-      />
-      <EventCard image={sceneThumbnail} sceneName="Upcoming Community Meetup" avatar={exampleAvatar} withShadow />
-    </StoryRow>
   )
 }
 
@@ -410,6 +363,67 @@ const MixedHeights: Story = {
   )
 }
 
+const LiftHover: Story = {
+  render: () => (
+    <StoryRow>
+      <EventCard
+        image={sceneThumbnail}
+        sceneName="Lift Hover Effect"
+        avatar={exampleAvatar}
+        hoverEffect="lift"
+        leftBadge={
+          <BadgeGroup>
+            <LiveBadge />
+            <UserCountBadge count={18} />
+          </BadgeGroup>
+        }
+        leftBadgeTransparent
+      />
+      <EventCard
+        image={sceneThumbnail}
+        sceneName="Another Lift Card"
+        avatar={exampleAvatar}
+        hoverEffect="lift"
+        leftBadge={<UserCountBadge count={7} />}
+        leftBadgeTransparent
+      />
+    </StoryRow>
+  )
+}
+
+const HoverEffects: Story = {
+  render: () => (
+    <StorySection>
+      <StoryRow>
+        <EventCard
+          image={sceneThumbnail}
+          sceneName="Coin (default)"
+          avatar={exampleAvatar}
+          withShadow
+          leftBadge={<LiveBadge />}
+          leftBadgeTransparent
+        />
+        <EventCard
+          image={sceneThumbnail}
+          sceneName="Lift"
+          avatar={exampleAvatar}
+          hoverEffect="lift"
+          leftBadge={<LiveBadge />}
+          leftBadgeTransparent
+        />
+        <EventCard
+          image={sceneThumbnail}
+          sceneName="None"
+          avatar={exampleAvatar}
+          hoverEffect="none"
+          leftBadge={<LiveBadge />}
+          leftBadgeTransparent
+        />
+      </StoryRow>
+    </StorySection>
+  )
+}
+
 // eslint-disable-next-line import/no-default-export
 export default meta
-export { Default, WithRedirectToAuth, OneCard, TwoCards, ThreeCards, CardQuantities, Multiline, WithoutAvatar, Loading, MixedHeights }
+export { Default, CoinHover, LiftHover, HoverEffects, WithRedirectToAuth, CardQuantities, Multiline, WithoutAvatar, Loading, MixedHeights }

--- a/src/components/EventCard/EventCard.styled.ts
+++ b/src/components/EventCard/EventCard.styled.ts
@@ -1,5 +1,6 @@
 import { Box, Card, CardActionArea, CardContent, CardMedia, Chip, Link, Skeleton, keyframes, styled } from '@mui/material'
 import { hexToRgba } from '../../utils/colors'
+import type { EventCardHoverEffect } from './EventCard.types'
 
 const JUMP_IN_BUTTON_HEIGHT = 46
 
@@ -13,9 +14,15 @@ const coinFlip = keyframes({
   '100%': { transform: 'perspective(800px) rotateX(0deg) rotateY(0deg)' }
 })
 
-const EventCardContainer = styled(Card)<{
+const LIFT_GLOW_DARK = `inset 0 0 0 3px ${hexToRgba('#FFFFFF', 0.35)}, inset 0 0 24px 0 ${hexToRgba('#FFFFFF', 0.08)}`
+const LIFT_GLOW_LIGHT = `inset 0 0 0 3px ${hexToRgba('#000000', 0.12)}, inset 0 0 24px 0 ${hexToRgba('#000000', 0.06)}`
+
+const EventCardContainer = styled(Card, {
+  shouldForwardProp: prop => prop !== 'withShadow' && prop !== 'hoverEffect'
+})<{
   withShadow?: boolean
-}>(({ theme, withShadow }) => ({
+  hoverEffect?: EventCardHoverEffect
+}>(({ theme, withShadow, hoverEffect = 'coin' }) => ({
   borderRadius: theme.spacing(2),
   boxSizing: 'border-box',
   minWidth: 400,
@@ -35,22 +42,30 @@ const EventCardContainer = styled(Card)<{
       duration: theme.transitions.duration.complex
     })
   ],
-
-  [theme.breakpoints.up('sm')]: {
-    '&:hover': {
-      boxShadow: withShadow ? `0px 0px 20px 6px ${hexToRgba('#DD56FF', 0.37)}` : 'none',
-      animation: `${coinFlip} 0.8s ease-in-out`,
-
-      transition: [
-        theme.transitions.create('transform', {
-          duration: theme.transitions.duration.complex
-        }),
-        theme.transitions.create('box-shadow', {
-          duration: theme.transitions.duration.complex
-        })
-      ].join(', ')
+  ...(hoverEffect === 'coin' && {
+    [theme.breakpoints.up('sm')]: {
+      '&:hover': {
+        boxShadow: withShadow ? `0px 0px 20px 6px ${hexToRgba('#DD56FF', 0.37)}` : 'none',
+        animation: `${coinFlip} 0.8s ease-in-out`,
+        transition: [
+          theme.transitions.create('transform', {
+            duration: theme.transitions.duration.complex
+          }),
+          theme.transitions.create('box-shadow', {
+            duration: theme.transitions.duration.complex
+          })
+        ].join(', ')
+      }
     }
-  }
+  }),
+  ...(hoverEffect === 'lift' && {
+    [theme.breakpoints.up('sm')]: {
+      '&:hover': {
+        transform: 'translateY(-4px)',
+        boxShadow: theme.palette.mode === 'dark' ? LIFT_GLOW_DARK : LIFT_GLOW_LIGHT
+      }
+    }
+  })
 }))
 
 const EventCardActionArea = styled(CardActionArea)(({ theme }) => ({

--- a/src/components/EventCard/EventCard.tsx
+++ b/src/components/EventCard/EventCard.tsx
@@ -36,6 +36,7 @@ const EventCard = memo((props: EventCardProps) => {
     avatar,
     coordinates,
     withShadow,
+    hoverEffect = 'coin',
     leftBadge,
     leftBadgeTransparent = false,
     onClick,
@@ -48,9 +49,23 @@ const EventCard = memo((props: EventCardProps) => {
   const isWorld = coordinates?.includes('.dcl.eth')
   const jumpInUrl = isWorld ? `https://decentraland.org/jump?realm=${coordinates}` : `https://decentraland.org/jump?position=${coordinates}`
 
+  const handleCardClick = useCallback(() => {
+    if (onClick) {
+      onClick()
+      return
+    }
+    if (redirectToAuth) {
+      window.location.href = '/auth'
+      return
+    }
+    if (coordinates) {
+      window.open(jumpInUrl, '_blank')
+    }
+  }, [onClick, redirectToAuth, coordinates, jumpInUrl])
+
   if (loading) {
     return (
-      <EventCardContainer>
+      <EventCardContainer hoverEffect="none">
         <EventCardActionArea disabled>
           <EventMediaContainer>
             <SkeletonImage variant="rectangular" />
@@ -71,22 +86,8 @@ const EventCard = memo((props: EventCardProps) => {
     )
   }
 
-  const handleCardClick = useCallback(() => {
-    if (onClick) {
-      onClick()
-      return
-    }
-    if (redirectToAuth) {
-      window.location.href = '/auth'
-      return
-    }
-    if (coordinates) {
-      window.open(jumpInUrl, '_blank')
-    }
-  }, [onClick, redirectToAuth, coordinates, jumpInUrl])
-
   return (
-    <EventCardContainer withShadow={withShadow}>
+    <EventCardContainer withShadow={withShadow} hoverEffect={hoverEffect}>
       <EventCardActionArea onClick={handleCardClick}>
         {leftBadge !== undefined && (
           <BadgesContainer>

--- a/src/components/EventCard/EventCard.types.ts
+++ b/src/components/EventCard/EventCard.types.ts
@@ -1,13 +1,23 @@
 import { ReactNode } from 'react'
 import { Avatar } from '@dcl/schemas'
 
+type EventCardHoverEffect = 'coin' | 'lift' | 'none'
+
 interface EventCardProps {
   image: string
   sceneName: string
   loading?: boolean
   avatar?: Avatar
   coordinates?: string
+  /** When true, adds a purple glow shadow on hover. Only applies to the 'coin' hover effect. */
   withShadow?: boolean
+  /**
+   * Hover animation style for the card container.
+   * - 'coin' (default): 3D flip animation with optional purple glow (controlled by withShadow)
+   * - 'lift': subtle translateY(-4px) with inset glow border
+   * - 'none': disables container hover animation. Note: child hover behaviors (image shrink, jump-in reveal) still apply.
+   */
+  hoverEffect?: EventCardHoverEffect
   leftBadge?: string | ReactNode
   /** When true, the left badge wrapper has no background/padding, useful when leftBadge already has its own styling */
   leftBadgeTransparent?: boolean
@@ -21,4 +31,4 @@ interface EventCardProps {
   hideLocation?: boolean
 }
 
-export type { EventCardProps }
+export type { EventCardHoverEffect, EventCardProps }

--- a/src/components/EventCard/index.ts
+++ b/src/components/EventCard/index.ts
@@ -1,2 +1,2 @@
 export { EventCard } from './EventCard'
-export type { EventCardProps } from './EventCard.types'
+export type { EventCardHoverEffect, EventCardProps } from './EventCard.types'


### PR DESCRIPTION
Adds configurable hover behavior to EventCard via a new `hoverEffect` prop.

**New prop:** `hoverEffect?: 'coin' | 'lift' | 'none'`

- `coin` (default) — existing 3D flip animation, backward-compatible
- `lift` — subtle translateY(-4px) + white/dark box-shadow, used by explore-site Live Now
- `none` — disables hover effects entirely

Shadow adapts to theme: white glow in dark mode, dark shadow in light mode.

Removed redundant OneCard/TwoCards/ThreeCards stories (covered by CardQuantities). Added CoinHover, LiftHover, and HoverEffects comparison stories.

No breaking changes — existing consumers without the prop get the same coin behavior.