### PR TITLE
fix: rename What's On navbar label to Explore

### DIFF
--- a/src/components/Navbar/Navbar.defaults.ts
+++ b/src/components/Navbar/Navbar.defaults.ts
@@ -4,7 +4,7 @@ import type { NavbarI18n } from './Navbar.types'
 const DEFAULT_I18N: NavbarI18n = {
   signIn: 'SIGN IN',
   signingIn: 'SIGNING IN...',
-  whatsOn: "What's On",
+  whatsOn: 'Explore',
   shop: 'Shop',
   shopAll: 'Shop All',
   wearables: 'Wearables',


### PR DESCRIPTION
Changes the default navbar label from "What's On" to "Explore". The i18n key remains `whatsOn` for backward compatibility — only the default display text changes.