### PR TITLE
fix: use data-role selectors for EventSmallCard hover targeting

### DIFF
--- a/src/components/EventSmallCard/EventSmallCard.styled.ts
+++ b/src/components/EventSmallCard/EventSmallCard.styled.ts
@@ -50,17 +50,17 @@ const EventSmallCardContainer = styled(Box, {
       transform: 'translateY(-4px)',
       boxShadow: theme.palette.mode === 'dark' ? HOVER_SHADOW : HOVER_SHADOW_LIGHT
     },
-    [`&:hover ${HoverActions}`]: {
+    '&:hover [data-role="hover-actions"]': {
       opacity: 1,
       transform: 'translateY(0)'
     },
-    [`&:hover ${TimePill}`]: {
+    '&:hover [data-role="time-pill"]': {
       opacity: 0
     }
   }),
   [theme.breakpoints.down('md')]: {
     minWidth: 0,
-    [`& ${HoverActions}`]: {
+    '& [data-role="hover-actions"]': {
       display: 'none'
     }
   }

--- a/src/components/EventSmallCard/EventSmallCard.tsx
+++ b/src/components/EventSmallCard/EventSmallCard.tsx
@@ -59,12 +59,12 @@ const EventSmallCard = memo(
             )}
           </ContentTop>
           {timeLabel && (
-            <TimePill>
+            <TimePill data-role="time-pill">
               <AccessTimeIcon sx={{ fontSize: 20, color: 'inherit' }} />
               <TimeLabel>{timeLabel}</TimeLabel>
             </TimePill>
           )}
-          {hoverActions && <HoverActions>{hoverActions}</HoverActions>}
+          {hoverActions && <HoverActions data-role="hover-actions">{hoverActions}</HoverActions>}
         </TextBlock>
       </EventSmallCardContainer>
     )


### PR DESCRIPTION
MUI's `styled()` does not support Emotion component reference selectors (`${Component}` in template literals) — they resolve to `no_component_selector` at runtime, breaking hover actions and time pill transitions.

Reverts to `data-role` attribute selectors which work correctly with MUI styled.

Verified locally in explore-site with `npm pack` + tgz install.