### PR TITLE
feat: optional MANA balances in navbar via showManaBalancesInNavbar prop

### DIFF
--- a/src/components/Navbar/Credits.styled.ts
+++ b/src/components/Navbar/Credits.styled.ts
@@ -57,4 +57,37 @@ const CreditsTooltip = styled('div')({
   zIndex: 10
 })
 
-export { CreditsBalanceButton, CreditsTooltip }
+const NavbarManaBalancesGroup = styled('div')({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 12,
+  flexShrink: 0
+})
+
+const NavbarManaBalanceButton = styled('button')<{ clickable?: boolean }>(({ clickable }) => ({
+  all: 'unset',
+  display: 'flex',
+  alignItems: 'center',
+  gap: 4,
+  cursor: clickable ? 'pointer' : 'default',
+  color: colors.neutral.softWhite,
+  fontFamily: 'Inter, Helvetica, Arial, sans-serif',
+  fontWeight: 600,
+  fontSize: 16,
+  letterSpacing: -0.8,
+  flexShrink: 0,
+  transition: 'opacity 0.15s ease',
+  '&:hover': clickable ? { opacity: 0.8 } : undefined,
+  '&:focus-visible': {
+    outline: `2px solid ${colors.base.primary}`,
+    outlineOffset: 2,
+    borderRadius: 4
+  },
+  '& svg': {
+    width: 20,
+    height: 20,
+    flexShrink: 0
+  }
+}))
+
+export { CreditsBalanceButton, CreditsTooltip, NavbarManaBalanceButton, NavbarManaBalancesGroup }

--- a/src/components/Navbar/Credits.styled.ts
+++ b/src/components/Navbar/Credits.styled.ts
@@ -30,8 +30,8 @@ const CreditsBalanceButton = styled('button')({
     flexShrink: 0
   },
   [MOBILE_BREAKPOINT]: {
-    fontSize: 14,
-    letterSpacing: -0.7,
+    fontSize: 12,
+    letterSpacing: -0.6,
     '&& svg': {
       width: 14,
       height: 14
@@ -100,8 +100,8 @@ const NavbarManaBalanceButton = styled('button')<{ clickable?: boolean }>(({ cli
   },
   [MOBILE_BREAKPOINT]: {
     gap: 2,
-    fontSize: 14,
-    letterSpacing: -0.7,
+    fontSize: 12,
+    letterSpacing: -0.6,
     '& svg': {
       width: 16,
       height: 16,

--- a/src/components/Navbar/Credits.styled.ts
+++ b/src/components/Navbar/Credits.styled.ts
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled'
 import * as colors from '../../theme/colors'
+import { DESKTOP_BREAKPOINT, MOBILE_BREAKPOINT } from './Navbar.styled'
 
 const CreditsBalanceButton = styled('button')({
   all: 'unset',
@@ -11,8 +12,6 @@ const CreditsBalanceButton = styled('button')({
   color: '#A0ABFF',
   fontFamily: 'Inter, Helvetica, Arial, sans-serif',
   fontWeight: 600,
-  fontSize: 16,
-  letterSpacing: -0.8,
   flexShrink: 0,
   transition: 'opacity 0.15s ease',
   '&:hover': {
@@ -27,10 +26,24 @@ const CreditsBalanceButton = styled('button')({
     outlineOffset: 2,
     borderRadius: 4
   },
-  '& svg': {
-    width: 20,
-    height: 20,
+  '&& svg': {
     flexShrink: 0
+  },
+  [MOBILE_BREAKPOINT]: {
+    fontSize: 14,
+    letterSpacing: -0.7,
+    '&& svg': {
+      width: 14,
+      height: 14
+    }
+  },
+  [DESKTOP_BREAKPOINT]: {
+    fontSize: 16,
+    letterSpacing: -0.8,
+    '&& svg': {
+      width: 20,
+      height: 20
+    }
   }
 })
 
@@ -60,21 +73,23 @@ const CreditsTooltip = styled('div')({
 const NavbarManaBalancesGroup = styled('div')({
   display: 'flex',
   alignItems: 'center',
-  gap: 12,
-  flexShrink: 0
+  flexShrink: 0,
+  [MOBILE_BREAKPOINT]: {
+    gap: 4
+  },
+  [DESKTOP_BREAKPOINT]: {
+    gap: 12
+  }
 })
 
 const NavbarManaBalanceButton = styled('button')<{ clickable?: boolean }>(({ clickable }) => ({
   all: 'unset',
   display: 'flex',
   alignItems: 'center',
-  gap: 4,
   cursor: clickable ? 'pointer' : 'default',
   color: colors.neutral.softWhite,
   fontFamily: 'Inter, Helvetica, Arial, sans-serif',
-  fontWeight: 600,
-  fontSize: 16,
-  letterSpacing: -0.8,
+  fontWeight: 400,
   flexShrink: 0,
   transition: 'opacity 0.15s ease',
   '&:hover': clickable ? { opacity: 0.8 } : undefined,
@@ -83,11 +98,43 @@ const NavbarManaBalanceButton = styled('button')<{ clickable?: boolean }>(({ cli
     outlineOffset: 2,
     borderRadius: 4
   },
-  '& svg': {
-    width: 20,
-    height: 20,
-    flexShrink: 0
+  [MOBILE_BREAKPOINT]: {
+    gap: 2,
+    fontSize: 14,
+    letterSpacing: -0.7,
+    '& svg': {
+      width: 16,
+      height: 16,
+      flexShrink: 0
+    }
+  },
+  [DESKTOP_BREAKPOINT]: {
+    gap: 4,
+    fontWeight: 600,
+    fontSize: 16,
+    letterSpacing: -0.8,
+    '& svg': {
+      width: 20,
+      height: 20,
+      flexShrink: 0
+    }
   }
 }))
 
-export { CreditsBalanceButton, CreditsTooltip, NavbarManaBalanceButton, NavbarManaBalancesGroup }
+const NavbarBalancesStack = styled('div')({
+  display: 'flex',
+  flexShrink: 0,
+  [MOBILE_BREAKPOINT]: {
+    flexDirection: 'column-reverse',
+    alignItems: 'flex-end',
+    justifyContent: 'center',
+    gap: 4
+  },
+  [DESKTOP_BREAKPOINT]: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 24
+  }
+})
+
+export { CreditsBalanceButton, CreditsTooltip, NavbarBalancesStack, NavbarManaBalanceButton, NavbarManaBalancesGroup }

--- a/src/components/Navbar/Credits.styled.ts
+++ b/src/components/Navbar/Credits.styled.ts
@@ -103,8 +103,8 @@ const NavbarManaBalanceButton = styled('button')<{ clickable?: boolean }>(({ cli
     fontSize: 12,
     letterSpacing: -0.6,
     '& svg': {
-      width: 16,
-      height: 16,
+      width: 14,
+      height: 14,
       flexShrink: 0
     }
   },

--- a/src/components/Navbar/Navbar.stories.tsx
+++ b/src/components/Navbar/Navbar.stories.tsx
@@ -217,6 +217,47 @@ const MarketplaceExample: Story = {
   }
 }
 
+const MarketplaceWithManaInNavbar: Story = {
+  args: {
+    isSignedIn: true,
+    address: '0xe3fc7040653768efb2941a6c26fdb868ed36ca99',
+    avatar: exampleAvatar,
+    selectedChain: ChainId.ETHEREUM_MAINNET,
+    chains: [
+      ChainId.ETHEREUM_MAINNET,
+      ChainId.MATIC_MAINNET,
+      ChainId.ARBITRUM_MAINNET,
+      ChainId.OPTIMISM_MAINNET,
+      ChainId.BSC_MAINNET,
+      ChainId.AVALANCHE_MAINNET,
+      ChainId.FANTOM_MAINNET
+    ],
+    onSelectChain: (chain: ChainId) => console.log('Selected chain', chain),
+    manaBalances: { [Network.ETHEREUM]: 1234, [Network.MATIC]: 5678 },
+    onClickBalance: (network: Network) => console.log('Clicked balance', network),
+    showManaBalancesInNavbar: true,
+    creditsBalance: { balance: 4200, expiresAt: Date.now() + 86400000 * 30 },
+    onClickCredits: () => console.log('Credits clicked'),
+    onClickSignIn: () => console.log('Sign In clicked'),
+    onClickSignOut: () => console.log('Sign Out clicked')
+  },
+  render: args => {
+    const [notifOpen, setNotifOpen] = useState(false)
+    return (
+      <>
+        <Navbar
+          {...args}
+          notificationSlot={<NotificationDemo isOpen={notifOpen} onToggle={() => setNotifOpen(prev => !prev)} />}
+          onToggleUserCard={isOpen => {
+            if (isOpen) setNotifOpen(false)
+          }}
+        />
+        <PageContent />
+      </>
+    )
+  }
+}
+
 const CustomI18n: Story = {
   args: {
     isSignedIn: false,
@@ -238,4 +279,4 @@ const CustomI18n: Story = {
   )
 }
 
-export { SignedOut, SignedIn, WithNotifications, MarketplaceExample, CustomI18n }
+export { SignedOut, SignedIn, WithNotifications, MarketplaceExample, MarketplaceWithManaInNavbar, CustomI18n }

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -8,7 +8,13 @@ import { NavLinks } from './NavLinks'
 import { UserCardPanel } from './UserCardPanel'
 import { CreditsIcon } from '../Icon/CreditsIcon'
 import type { NavbarI18n, NavbarProps } from './Navbar.types'
-import { CreditsBalanceButton, CreditsTooltip, NavbarManaBalanceButton, NavbarManaBalancesGroup } from './Credits.styled'
+import {
+  CreditsBalanceButton,
+  CreditsTooltip,
+  NavbarBalancesStack,
+  NavbarManaBalanceButton,
+  NavbarManaBalancesGroup
+} from './Credits.styled'
 import { HamburgerButton, LogoLink, NavbarLeft, NavbarRight, NavbarRightGroup, NavbarRoot, SignInButton } from './Navbar.styled'
 import type { DropdownSection } from './Navbar.defaults'
 
@@ -164,41 +170,45 @@ const Navbar = memo(function Navbar({
         <NavbarRight>
           {isSignedIn && (
             <NavbarRightGroup>
-              {creditsBalance && (
-                <CreditsBalanceButton onClick={onClickCredits} aria-label={`${formatBalance(creditsBalance.balance)} credits`}>
-                  <CreditsIcon sx={{ width: 20, height: 20 }} />
-                  {formatBalance(creditsBalance.balance)}
-                  <CreditsTooltip className="credits-tooltip">
-                    {i18n.creditsExpiringIn.replace('{days}', String(daysUntil(creditsBalance.expiresAt)))}
-                    <br />
-                    {i18n.creditsValueNote}
-                  </CreditsTooltip>
-                </CreditsBalanceButton>
-              )}
+              {(creditsBalance || (showManaBalancesInNavbar && manaBalances)) && (
+                <NavbarBalancesStack>
+                  {creditsBalance && (
+                    <CreditsBalanceButton onClick={onClickCredits} aria-label={`${formatBalance(creditsBalance.balance)} credits`}>
+                      <CreditsIcon />
+                      {formatBalance(creditsBalance.balance)}
+                      <CreditsTooltip className="credits-tooltip">
+                        {i18n.creditsExpiringIn.replace('{days}', String(daysUntil(creditsBalance.expiresAt)))}
+                        <br />
+                        {i18n.creditsValueNote}
+                      </CreditsTooltip>
+                    </CreditsBalanceButton>
+                  )}
 
-              {showManaBalancesInNavbar && manaBalances && (
-                <NavbarManaBalancesGroup>
-                  {manaBalances.ETHEREUM !== undefined && (
-                    <NavbarManaBalanceButton
-                      clickable={!!onClickBalance}
-                      onClick={onClickBalance ? () => onClickBalance(Network.ETHEREUM) : undefined}
-                      aria-label={`${formatBalance(manaBalances.ETHEREUM)} MANA on Ethereum`}
-                    >
-                      <ManaEthInlineIcon />
-                      {formatBalance(manaBalances.ETHEREUM)}
-                    </NavbarManaBalanceButton>
+                  {showManaBalancesInNavbar && manaBalances && (
+                    <NavbarManaBalancesGroup>
+                      {manaBalances.ETHEREUM !== undefined && (
+                        <NavbarManaBalanceButton
+                          clickable={!!onClickBalance}
+                          onClick={onClickBalance ? () => onClickBalance(Network.ETHEREUM) : undefined}
+                          aria-label={`${formatBalance(manaBalances.ETHEREUM)} MANA on Ethereum`}
+                        >
+                          <ManaEthInlineIcon />
+                          {formatBalance(manaBalances.ETHEREUM)}
+                        </NavbarManaBalanceButton>
+                      )}
+                      {manaBalances.MATIC !== undefined && (
+                        <NavbarManaBalanceButton
+                          clickable={!!onClickBalance}
+                          onClick={onClickBalance ? () => onClickBalance(Network.MATIC) : undefined}
+                          aria-label={`${formatBalance(manaBalances.MATIC)} MANA on Polygon`}
+                        >
+                          <ManaMaticInlineIcon />
+                          {formatBalance(manaBalances.MATIC)}
+                        </NavbarManaBalanceButton>
+                      )}
+                    </NavbarManaBalancesGroup>
                   )}
-                  {manaBalances.MATIC !== undefined && (
-                    <NavbarManaBalanceButton
-                      clickable={!!onClickBalance}
-                      onClick={onClickBalance ? () => onClickBalance(Network.MATIC) : undefined}
-                      aria-label={`${formatBalance(manaBalances.MATIC)} MANA on Polygon`}
-                    >
-                      <ManaMaticInlineIcon />
-                      {formatBalance(manaBalances.MATIC)}
-                    </NavbarManaBalanceButton>
-                  )}
-                </NavbarManaBalancesGroup>
+                </NavbarBalancesStack>
               )}
 
               {notificationSlot && (

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -1,13 +1,14 @@
 import { memo, useCallback, useEffect, useRef, useState } from 'react'
+import { Network } from '@dcl/schemas/dist/dapps/network'
 import { formatBalance } from './formatBalance'
-import { CloseIcon, DclLogo, HamburgerIcon } from './icons'
+import { CloseIcon, DclLogo, HamburgerIcon, ManaEthInlineIcon, ManaMaticInlineIcon } from './icons'
 import { MobileMenu } from './MobileMenu'
 import { DEFAULT_I18N } from './Navbar.defaults'
 import { NavLinks } from './NavLinks'
 import { UserCardPanel } from './UserCardPanel'
 import { CreditsIcon } from '../Icon/CreditsIcon'
 import type { NavbarI18n, NavbarProps } from './Navbar.types'
-import { CreditsBalanceButton, CreditsTooltip } from './Credits.styled'
+import { CreditsBalanceButton, CreditsTooltip, NavbarManaBalanceButton, NavbarManaBalancesGroup } from './Credits.styled'
 import { HamburgerButton, LogoLink, NavbarLeft, NavbarRight, NavbarRightGroup, NavbarRoot, SignInButton } from './Navbar.styled'
 import type { DropdownSection } from './Navbar.defaults'
 
@@ -30,6 +31,7 @@ const Navbar = memo(function Navbar({
   onSelectChain,
   manaBalances,
   onClickBalance,
+  showManaBalancesInNavbar = false,
   creditsBalance,
   onClickCredits,
   activePage,
@@ -174,6 +176,31 @@ const Navbar = memo(function Navbar({
                 </CreditsBalanceButton>
               )}
 
+              {showManaBalancesInNavbar && manaBalances && (
+                <NavbarManaBalancesGroup>
+                  {manaBalances.ETHEREUM !== undefined && (
+                    <NavbarManaBalanceButton
+                      clickable={!!onClickBalance}
+                      onClick={onClickBalance ? () => onClickBalance(Network.ETHEREUM) : undefined}
+                      aria-label={`${formatBalance(manaBalances.ETHEREUM)} MANA on Ethereum`}
+                    >
+                      <ManaEthInlineIcon />
+                      {formatBalance(manaBalances.ETHEREUM)}
+                    </NavbarManaBalanceButton>
+                  )}
+                  {manaBalances.MATIC !== undefined && (
+                    <NavbarManaBalanceButton
+                      clickable={!!onClickBalance}
+                      onClick={onClickBalance ? () => onClickBalance(Network.MATIC) : undefined}
+                      aria-label={`${formatBalance(manaBalances.MATIC)} MANA on Polygon`}
+                    >
+                      <ManaMaticInlineIcon />
+                      {formatBalance(manaBalances.MATIC)}
+                    </NavbarManaBalanceButton>
+                  )}
+                </NavbarManaBalancesGroup>
+              )}
+
               {notificationSlot && (
                 <div
                   onClick={() => {
@@ -195,8 +222,8 @@ const Navbar = memo(function Navbar({
                 selectedChain={selectedChain}
                 chains={chains}
                 onSelectChain={onSelectChain}
-                manaBalances={manaBalances}
-                onClickBalance={onClickBalance}
+                manaBalances={showManaBalancesInNavbar ? undefined : manaBalances}
+                onClickBalance={showManaBalancesInNavbar ? undefined : onClickBalance}
                 i18n={i18n}
               />
             </NavbarRightGroup>

--- a/src/components/Navbar/Navbar.types.ts
+++ b/src/components/Navbar/Navbar.types.ts
@@ -50,6 +50,9 @@ type NavbarProps = {
   manaBalances?: Partial<Record<Network, number>>
   /** Called when the user clicks a balance entry */
   onClickBalance?: (network: Network) => void
+  /** When true, MANA balances are rendered in the navbar (next to credits)
+   *  instead of inside the user card panel. */
+  showManaBalancesInNavbar?: boolean
   /** Credits balance to display in the navbar top bar */
   creditsBalance?: { balance: number; expiresAt: number }
   /** Called when the user clicks the credits balance */


### PR DESCRIPTION
## Summary
- Adds a new `showManaBalancesInNavbar?: boolean` prop to `Navbar`. When `true`, ETH and MATIC MANA balances render in the navbar to the right of the credits balance; when omitted/`false`, behavior is unchanged and the balances remain inside the user card panel.
- Adds matching navbar-styled buttons (`NavbarManaBalanceButton`, `NavbarManaBalancesGroup`) in `Credits.styled.ts` consistent with the credits button (16px Inter 600, hover/focus states).
- Suppresses the in-card MANA balances when the new prop is on, so they aren't duplicated.
- New Storybook story `MarketplaceWithManaInNavbar` to preview the outside layout.

## Test plan
- [ ] Storybook: `Decentraland UI / Navbar / Marketplace Example` — MANA still inside user card.
- [ ] Storybook: `Decentraland UI / Navbar / Marketplace With Mana In Navbar` — MANA appears next to credits, not inside the user card.
- [ ] Click MANA balances triggers `onClickBalance(network)` in both modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)