### PR TITLE
feat: event card avatar click handler

### DIFF
--- a/src/components/EventCard/EventCard.styled.ts
+++ b/src/components/EventCard/EventCard.styled.ts
@@ -218,6 +218,10 @@ const AvatarTextContainer = styled(Box)({
 const AvatarLink = styled(Link)(({ theme }) => ({
   textDecoration: 'none',
   fontWeight: theme.typography.fontWeightBold,
+  // When rendered without href (e.g. when a parent supplies onAvatarClick),
+  // the browser strips the link affordance; restore the pointer cursor so the
+  // interaction stays obvious.
+  cursor: 'pointer',
   '&:hover': {
     textDecoration: 'none'
   }

--- a/src/components/EventCard/EventCard.tsx
+++ b/src/components/EventCard/EventCard.tsx
@@ -42,10 +42,21 @@ const EventCard = memo((props: EventCardProps) => {
     leftBadgeTransparent = false,
     onClick,
     onJumpInClick,
+    onAvatarClick,
     redirectToAuth = false,
     hideLocation = false,
     loading = false
   } = props
+
+  const handleAvatarClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (!onAvatarClick) return
+      e.preventDefault()
+      e.stopPropagation()
+      onAvatarClick()
+    },
+    [onAvatarClick]
+  )
 
   const isWorld = coordinates?.includes('.dcl.eth')
   const jumpInUrl = isWorld ? `https://decentraland.org/jump?realm=${coordinates}` : `https://decentraland.org/jump?position=${coordinates}`
@@ -114,7 +125,15 @@ const EventCard = memo((props: EventCardProps) => {
                     <AvatarFace size="small" avatar={avatar} />
                     <AvatarTextContainer>
                       <Typography variant="body2">
-                        by <AvatarLink href={`https://decentraland.org/profile/accounts/${avatar.ethAddress}`}>{avatar.name}</AvatarLink>
+                        by{' '}
+                        <AvatarLink
+                          href={onAvatarClick ? undefined : `https://decentraland.org/profile/accounts/${avatar.ethAddress}`}
+                          onClick={onAvatarClick ? handleAvatarClick : undefined}
+                          role={onAvatarClick ? 'button' : undefined}
+                          tabIndex={onAvatarClick ? 0 : undefined}
+                        >
+                          {avatar.name}
+                        </AvatarLink>
                       </Typography>
                     </AvatarTextContainer>
                   </AvatarContainer>

--- a/src/components/EventCard/EventCard.types.ts
+++ b/src/components/EventCard/EventCard.types.ts
@@ -27,6 +27,13 @@ interface EventCardProps {
   onClick?: () => void
   /** Custom handler for the Jump In button. When provided, clicking the button calls this instead of the card's onClick */
   onJumpInClick?: () => void
+  /**
+   * Custom handler for the avatar/creator name. When provided, the avatar row becomes a button:
+   * click calls this instead of navigating to the legacy `decentraland.org/profile/accounts/<addr>`
+   * URL, and the card-level click handler is suppressed via stopPropagation (so you don't get the
+   * card's jump-in action firing in a second tab alongside the profile navigation).
+   */
+  onAvatarClick?: () => void
   /** When true, clicking the card redirects to /auth instead of the jump-in URL */
   redirectToAuth?: boolean
   /** When true, the location chip is not shown on hover */


### PR DESCRIPTION
adds an optional `onAvatarClick` handler to `EventCard`.

today the creator row is a hard link to the legacy `decentraland.org/profile/accounts/<addr>` URL and it sits inside the card's action area, so clicking the avatar both navigated to the legacy profile AND fired the card-level jump-in in a second tab. when `onAvatarClick` is provided the row renders as a button (`preventDefault` + `stopPropagation`) and delegates navigation to the consumer — sites uses it to open its native `/profile/<addr>` route. without the prop the behavior is unchanged (backward compatible, optional with default).

## test plan

- [ ] storybook EventCard: without `onAvatarClick`, the creator link still navigates to the legacy profile URL
- [ ] with `onAvatarClick`: clicking the creator name fires the handler only — no second tab, no card-level jump-in
- [ ] keyboard: the creator row is focusable (`role="button"`, `tabIndex=0`) when the handler is provided
