### PR TITLE
fix: make asset preview overlay z-index configurable

### DIFF
--- a/src/components/AssetPreviewPlayer/AssetPreviewPlayer.styled.ts
+++ b/src/components/AssetPreviewPlayer/AssetPreviewPlayer.styled.ts
@@ -6,11 +6,15 @@ import styled from '@emotion/styled'
  * origin hidden via `clip-path` — NOT `visibility: hidden`, which can pause the
  * iframe's render loop and defeat the pre-warming.
  */
-const PlayerOverlay = styled('div')<{ visible: boolean }>(({ visible }) => ({
+const PlayerOverlay = styled('div')<{ visible: boolean; overlayZIndex?: number }>(({ visible, overlayZIndex }) => ({
   position: 'fixed',
-  // Above MUI dialogs (zIndex.modal = 1300) so cards hovered inside a profile/event
-  // modal still get their preview; pointer-events stays none so nothing is blocked.
-  zIndex: 1600,
+  // Default sits above page content but BELOW app chrome — the MUI `appBar` (1100),
+  // `modal` (1300), `snackbar` (1400) and `tooltip` (1500) layers — so the floating
+  // preview never covers a fixed navbar, an open dialog or a toast. `pointer-events`
+  // stays none so nothing is blocked. When the previewed card itself lives inside a
+  // modal, the consumer passes a higher `overlayZIndex` (e.g. above 1300) so the
+  // preview floats over that modal's own content.
+  zIndex: overlayZIndex ?? 1050,
   borderRadius: 10,
   overflow: 'hidden',
   // Clicks fall through to the card underneath (navigation keeps working).

--- a/src/components/AssetPreviewPlayer/AssetPreviewPlayer.tsx
+++ b/src/components/AssetPreviewPlayer/AssetPreviewPlayer.tsx
@@ -71,6 +71,7 @@ function AssetPreviewPlayerProvider({
   marketplaceServerUrl = DEFAULT_MARKETPLACE_SERVER_URL,
   profile = 'default',
   dev = false,
+  overlayZIndex,
   children
 }: AssetPreviewPlayerProviderProps) {
   const [isVisible, setIsVisible] = useState(false)
@@ -204,7 +205,7 @@ function AssetPreviewPlayerProvider({
       {children}
       {enabled
         ? createPortal(
-            <PlayerOverlay visible={Boolean(isVisible && rect)} style={overlayStyle} aria-hidden>
+            <PlayerOverlay visible={Boolean(isVisible && rect)} overlayZIndex={overlayZIndex} style={overlayStyle} aria-hidden>
               <WearablePreview
                 id={PREVIEW_IFRAME_ID}
                 profile={profile}

--- a/src/components/AssetPreviewPlayer/AssetPreviewPlayer.types.ts
+++ b/src/components/AssetPreviewPlayer/AssetPreviewPlayer.types.ts
@@ -34,6 +34,14 @@ type AssetPreviewPlayerProviderProps = {
   profile?: string
   /** Forwarded to the preview iframe (zone assets). */
   dev?: boolean
+  /**
+   * z-index of the floating preview overlay. Defaults to `1050` — above page content
+   * but below app chrome (MUI `appBar` 1100 / `modal` 1300 / `snackbar` 1400 /
+   * `tooltip` 1500) — so the preview never covers a fixed navbar, dialog or toast.
+   * When the previewed cards live inside a modal, pass a value above the modal layer
+   * (e.g. `1600`) so the preview floats over that modal's content.
+   */
+  overlayZIndex?: number
   children: React.ReactNode
 }
 


### PR DESCRIPTION
The shared asset-preview overlay is portaled to `document.body` with a fixed `z-index` so a hovered card's live preview floats over the card. It was hardcoded to `1600`, which sits above every MUI chrome layer (`appBar` 1100, `modal` 1300, `snackbar` 1400, `tooltip` 1500) — so on a bare page the preview renders over the fixed navbar, and in general it can cover dialogs/toasts it shouldn't.

This exposes the overlay z-index as an optional `overlayZIndex` prop on `AssetPreviewPlayerProvider` and lowers the default to `1050` — above page content but below app chrome — so the preview no longer covers the navbar, modals or toasts by default. The one case that needs to float above a modal (cards hovered *inside* a dialog) opts in by passing a higher value (e.g. `1600`).

Verified with `npm run build` (tsc) and lint.
