### PR TITLE
feat: expose dclenv and scene-console in JumpIn desktopAppOptions

### DIFF
--- a/src/components/JumpIn/JumpIn.stories.tsx
+++ b/src/components/JumpIn/JumpIn.stories.tsx
@@ -66,7 +66,7 @@ const meta = {
     },
     desktopAppOptions: {
       control: 'object',
-      description: 'Options for the desktop app (position, realm)'
+      description: 'Options forwarded to the desktop app deep link (position, realm, communityId, dclenv, sceneConsole)'
     },
     onTrack: {
       action: 'onTrack',
@@ -177,6 +177,28 @@ const IconHidden: Story = {
   }
 }
 
+const WithDeepLinkOptions: Story = {
+  args: {
+    variant: 'button',
+    buttonText: 'Jump In',
+    modalProps: defaultModalProps,
+    desktopAppOptions: {
+      position: '10,20',
+      realm: 'my-world.dcl.eth',
+      dclenv: 'zone',
+      sceneConsole: 'true'
+    }
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Forwards deep-link options to the desktop app: `position`/`realm` for the destination, `dclenv` for the target Explorer environment, and `sceneConsole` to open the in-scene console on launch.'
+      }
+    }
+  }
+}
+
 const AllVariants: Story = {
   args: {
     variant: 'button',
@@ -202,4 +224,4 @@ const AllVariants: Story = {
 // eslint-disable-next-line import/no-default-export
 export default meta
 
-export { Button, ButtonLoading, Link, CompactLink, WorldLink, CustomModal, WithTracking, IconHidden, AllVariants }
+export { Button, ButtonLoading, Link, CompactLink, WorldLink, CustomModal, WithTracking, IconHidden, WithDeepLinkOptions, AllVariants }

--- a/src/components/JumpIn/JumpIn.types.ts
+++ b/src/components/JumpIn/JumpIn.types.ts
@@ -1,4 +1,5 @@
 import { ButtonProps, LinkProps } from '@mui/material'
+import { JumpInOptions } from '../../modules/jumpIn'
 import { DownloadModalProps } from '../Modal/DownloadModal/DownloadModal.types'
 
 enum JumpInEventType {
@@ -30,12 +31,12 @@ type JumpInBaseProps = {
   hideIcon?: boolean
   /** Props for the download modal */
   modalProps: Omit<DownloadModalProps, 'open' | 'onClose'>
-  /** Options for the desktop app */
-  desktopAppOptions?: {
-    position?: string
-    realm?: string
-    communityId?: string
-  }
+  /**
+   * Options forwarded to the desktop app deep link. Subset of `JumpInOptions`
+   * so `dclenv` and `scene-console` reach `launchDesktopApp` without the type
+   * drifting from the module it feeds.
+   */
+  desktopAppOptions?: Pick<JumpInOptions, 'position' | 'realm' | 'communityId' | 'dclenv' | 'sceneConsole'>
 }
 
 type JumpInProps = JumpInBaseProps &

--- a/src/modules/jumpIn.ts
+++ b/src/modules/jumpIn.ts
@@ -99,3 +99,5 @@ export function launchDesktopApp(opts: JumpInOptions = {}): Promise<boolean> {
     }
   })
 }
+
+export type { JumpInOptions }


### PR DESCRIPTION
The `JumpIn` component's `desktopAppOptions` prop only accepted `position`, `realm` and `communityId`, while the underlying `launchDesktopApp` (`src/modules/jumpIn.ts`) already supports `dclenv` (#441) and `scene-console` (#455). Consumers of the component could not forward those two deep-link params even though the primitive handles them.

Changes:
- `desktopAppOptions` is now `Pick<JumpInOptions, 'position' | 'realm' | 'communityId' | 'dclenv' | 'sceneConsole'>`, so it stays in sync with the module it feeds and exposes `dclenv` + `sceneConsole`.
- `JumpInOptions` is now exported from `src/modules/jumpIn.ts` (flows through the existing `export *` in `src/index.ts`) so consumers of `launchDesktopApp` can type the options.
- Added a `WithDeepLinkOptions` story documenting the new fields.

Additive and backward-compatible: every field stays optional, no existing prop or type is narrowed.

Verified locally: prettier, eslint, lint:package-json, `tsc` build and the jest suite all pass.