### PR TITLE
feat: add EmptyState component

### DIFF
--- a/src/components/EmptyState/EmptyState.stories.tsx
+++ b/src/components/EmptyState/EmptyState.stories.tsx
@@ -1,0 +1,85 @@
+import ImageOutlined from '@mui/icons-material/ImageOutlined'
+import SearchOffOutlined from '@mui/icons-material/SearchOffOutlined'
+import { EmptyState } from './EmptyState'
+import { EmptyStateProps } from './EmptyState.types'
+import type { Meta, StoryObj } from '@storybook/react'
+
+const meta = {
+  title: 'Decentraland UI/EmptyState',
+  component: EmptyState,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Presentational empty-state / not-found panel: an optional bordered icon, a title, an optional subtitle and an optional primary CTA. Routing, analytics and i18n stay at the call site.'
+      }
+    }
+  },
+  argTypes: {
+    title: { control: 'text', description: 'Primary heading' },
+    subtitle: { control: 'text', description: 'Optional supporting copy' },
+    action: { control: 'object', description: 'Optional primary CTA — external `href` or in-app `onClick` (never both)' }
+  }
+} satisfies Meta<EmptyStateProps>
+
+type Story = StoryObj<typeof meta>
+
+const WithIconAndLink: Story = {
+  args: {
+    icon: <ImageOutlined />,
+    title: 'No collectibles yet',
+    subtitle: 'Explore the marketplace to start your collection.',
+    action: { label: 'Browse Marketplace', href: 'https://decentraland.org/marketplace' }
+  }
+}
+
+const WithClickHandler: Story = {
+  args: {
+    icon: <ImageOutlined />,
+    title: 'No communities yet',
+    subtitle: 'Jump into Decentraland to find your people.',
+    action: { label: 'Jump In', onClick: () => alert('launch') }
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'In-app CTA: the consumer wires `onClick` (e.g. a launcher or a router navigation).'
+      }
+    }
+  }
+}
+
+const NotFound: Story = {
+  args: {
+    icon: <SearchOffOutlined />,
+    title: 'Page not found',
+    subtitle: "The page you're looking for doesn't exist or has moved.",
+    action: { label: 'Go Home', href: '/' }
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Reused as a not-found panel inside an area layout.'
+      }
+    }
+  }
+}
+
+const WithoutIcon: Story = {
+  args: {
+    title: 'Nothing here',
+    subtitle: 'This tab is empty.'
+  }
+}
+
+const TitleOnly: Story = {
+  args: {
+    title: 'No results'
+  }
+}
+
+// eslint-disable-next-line import/no-default-export
+export default meta
+export { WithIconAndLink, WithClickHandler, NotFound, WithoutIcon, TitleOnly }

--- a/src/components/EmptyState/EmptyState.styled.ts
+++ b/src/components/EmptyState/EmptyState.styled.ts
@@ -1,0 +1,76 @@
+import styled from '@emotion/styled'
+import { Box, Typography } from '@mui/material'
+import { neutral } from '../../theme/colors'
+import { Button } from '../Button'
+
+// Centered column: bordered icon box, then a text/CTA block. Generalized from the
+// Figma "EmptyMessage" composition (icon 100×100, 20px icon→text gap).
+const EmptyStateBox = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  textAlign: 'center',
+  gap: 20,
+  padding: theme.spacing(10, 2),
+  [theme.breakpoints.down('md')]: {
+    padding: theme.spacing(6, 2)
+  }
+}))
+
+// 100×100 box, 4px soft-white border, 24px radius, glyph centered inside.
+const EmptyStateIcon = styled(Box)({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  flexShrink: 0,
+  width: 100,
+  height: 100,
+  borderRadius: 24,
+  border: `4px solid ${neutral.softWhite}`,
+  color: neutral.softWhite,
+  ['& .MuiSvgIcon-root']: { fontSize: 56 },
+  ['& svg']: { width: 56, height: 56 }
+})
+
+// Title → subtitle → CTA share a tighter 10px rhythm, offset 10px from the icon.
+const EmptyStateBody = styled(Box)({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  gap: 10,
+  paddingTop: 10
+})
+
+// Figma typography/h6: Inter Medium 20, soft-white, line 1.6.
+const EmptyStateTitle = styled(Typography)({
+  color: neutral.softWhite,
+  fontWeight: 500,
+  fontSize: 20,
+  lineHeight: 1.6,
+  maxWidth: 452
+})
+
+// Figma typography/body1: Inter Regular 16, soft-white, line 1.5.
+const EmptyStateSubtitle = styled(Typography)({
+  color: neutral.softWhite,
+  fontWeight: 400,
+  fontSize: 16,
+  lineHeight: 1.5,
+  maxWidth: 436
+})
+
+// Figma "PrimaryCTA" / button/medium: h46, 16px padding, radius 12, uppercase.
+const EmptyStateButton = styled(Button)(({ theme }) => ({
+  marginTop: theme.spacing(0.5),
+  height: 46,
+  padding: theme.spacing(0, 2),
+  borderRadius: 12,
+  fontSize: 14,
+  fontWeight: 600,
+  letterSpacing: '0.4px',
+  lineHeight: '24px',
+  textTransform: 'uppercase'
+}))
+
+export { EmptyStateBody, EmptyStateBox, EmptyStateButton, EmptyStateIcon, EmptyStateSubtitle, EmptyStateTitle }

--- a/src/components/EmptyState/EmptyState.tsx
+++ b/src/components/EmptyState/EmptyState.tsx
@@ -1,0 +1,35 @@
+import { memo } from 'react'
+import { EmptyStateProps } from './EmptyState.types'
+import { EmptyStateBody, EmptyStateBox, EmptyStateButton, EmptyStateIcon, EmptyStateSubtitle, EmptyStateTitle } from './EmptyState.styled'
+
+/**
+ * Presentational empty-state / not-found panel: an optional bordered icon, a
+ * title, an optional subtitle and an optional primary CTA. Routing, analytics
+ * and i18n stay at the call site — the CTA is either an external `href` or an
+ * `onClick`, and `buttonProps` forwards escape hatches like `component={Link}`.
+ */
+const EmptyState = memo(function EmptyState({ icon, title, subtitle, action, buttonProps, className }: EmptyStateProps) {
+  return (
+    <EmptyStateBox className={className}>
+      {icon ? <EmptyStateIcon>{icon}</EmptyStateIcon> : null}
+      <EmptyStateBody>
+        <EmptyStateTitle>{title}</EmptyStateTitle>
+        {subtitle ? <EmptyStateSubtitle>{subtitle}</EmptyStateSubtitle> : null}
+        {action ? (
+          <EmptyStateButton
+            variant="contained"
+            color="primary"
+            startIcon={action.startIcon}
+            endIcon={action.endIcon}
+            {...(action.href ? { href: action.href, target: '_blank', rel: 'noopener noreferrer' } : { onClick: action.onClick })}
+            {...buttonProps}
+          >
+            {action.label}
+          </EmptyStateButton>
+        ) : null}
+      </EmptyStateBody>
+    </EmptyStateBox>
+  )
+})
+
+export { EmptyState }

--- a/src/components/EmptyState/EmptyState.types.ts
+++ b/src/components/EmptyState/EmptyState.types.ts
@@ -1,0 +1,34 @@
+import { MouseEvent, ReactNode } from 'react'
+import { ButtonProps } from '../Button'
+
+interface EmptyStateActionBase {
+  /** CTA label. */
+  label: string
+  startIcon?: ReactNode
+  endIcon?: ReactNode
+}
+
+/**
+ * The primary CTA is either an external link (`href`, opened in a new tab) or an
+ * in-app handler (`onClick`) — never both. The discriminated union enforces that
+ * at compile time so the consumer wires routing/analytics on its own side.
+ */
+type EmptyStateAction = EmptyStateActionBase &
+  ({ href: string; onClick?: never } | { href?: never; onClick: (event: MouseEvent<HTMLButtonElement>) => void })
+
+interface EmptyStateProps {
+  /** Optional glyph rendered inside the bordered icon box. Omit for a text-only empty state. */
+  icon?: ReactNode
+  /** Primary heading. */
+  title: string
+  /** Optional supporting copy under the title. */
+  subtitle?: ReactNode
+  /** Optional primary CTA. Rendered only when provided. */
+  action?: EmptyStateAction
+  /** Escape hatch forwarded to the CTA button (e.g. `component={Link}` for client-side routing). */
+  buttonProps?: Partial<ButtonProps>
+  /** Forwarded to the root element (e.g. layout overrides at the call site). */
+  className?: string
+}
+
+export type { EmptyStateAction, EmptyStateProps }

--- a/src/components/EmptyState/index.ts
+++ b/src/components/EmptyState/index.ts
@@ -1,0 +1,2 @@
+export { EmptyState } from './EmptyState'
+export type { EmptyStateAction, EmptyStateProps } from './EmptyState.types'

--- a/src/index.ts
+++ b/src/index.ts
@@ -193,6 +193,7 @@ export * from './components/EventCard'
 export * from './components/EventSmallCard'
 export * from './components/ScenesTable'
 export * from './components/Badges'
+export * from './components/EmptyState'
 export * as dclTable from './components/Table'
 
 export * as dclNetworkUtils from './lib/network'


### PR DESCRIPTION
Adds a presentational `EmptyState` component: an optional bordered icon, a title, an optional subtitle and an optional primary CTA. It generalizes the empty-state/not-found panel that consuming apps (sites) hand-roll in several places (profile empty tabs, area-scoped not-found pages).

Design boundary — routing, analytics and i18n stay at the call site:
- The CTA is a discriminated union: either an external `href` (opened in a new tab) or an in-app `onClick`, never both, enforced at compile time.
- `buttonProps` is an escape hatch forwarded to the CTA (e.g. `component={Link}` for client-side routing).
- `icon` is optional so it also serves text-only empty states and not-found panels.

The CTA reuses ui2's own `Button` (theme-aware) and the panel uses theme spacing/breakpoints and the `neutral.softWhite` token — no hardcoded colors.

Public API (`EmptyState`, `EmptyStateProps`, `EmptyStateAction`) exported through `src/index.ts`. Additive; no existing component or type changed.

Verified locally: prettier, eslint, lint:package-json, `tsc` build and the jest suite all pass. Storybook stories added (`Decentraland UI/EmptyState`): icon + link, click handler, not-found, without icon, title-only.