### PR TITLE
feat: add Video component

### DIFF
--- a/src/components/Video/Video.stories.tsx
+++ b/src/components/Video/Video.stories.tsx
@@ -1,0 +1,59 @@
+import { Video } from './Video'
+import { VideoProps } from './Video.types'
+import type { Meta, StoryObj } from '@storybook/react'
+
+const SAMPLE_SRC = 'https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4'
+
+const meta = {
+  title: 'Decentraland UI/Video',
+  component: Video,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Autoplay-safe wrapper over a native `<video>`. When `play` is a boolean it imperatively plays/pauses and retries muted if the browser blocks autoplay with sound. Leave `play` undefined to control it via native attributes.'
+      }
+    }
+  },
+  argTypes: {
+    play: { control: 'boolean', description: 'Imperatively play (true) / pause (false). Undefined = native control.' },
+    source: { control: 'text', description: 'Video source URL (forwarded to `src`)' },
+    loop: { control: 'boolean' },
+    muted: { control: 'boolean' },
+    controls: { control: 'boolean' }
+  }
+} satisfies Meta<VideoProps>
+
+type Story = StoryObj<typeof meta>
+
+const WithControls: Story = {
+  args: {
+    source: SAMPLE_SRC,
+    controls: true,
+    width: 480
+  }
+}
+
+const ImperativePlay: Story = {
+  args: {
+    source: SAMPLE_SRC,
+    play: true,
+    loop: true,
+    muted: true,
+    playsInline: true,
+    width: 480
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Driven by the `play` prop. Toggle it in the controls panel to play/pause; muted + loop for a background-video style.'
+      }
+    }
+  }
+}
+
+// eslint-disable-next-line import/no-default-export
+export default meta
+export { WithControls, ImperativePlay }

--- a/src/components/Video/Video.tsx
+++ b/src/components/Video/Video.tsx
@@ -1,0 +1,51 @@
+import { memo, useEffect, useRef } from 'react'
+import { VideoProps } from './Video.types'
+
+/**
+ * Thin, autoplay-safe wrapper over a native `<video>`. When `play` is a boolean
+ * it imperatively plays/pauses the element and, if the browser blocks autoplay
+ * with sound, retries muted before giving up. Leave `play` undefined to fall
+ * back to native attribute control (`autoPlay`, `controls`, …). All other props
+ * are forwarded to the underlying `<video>`.
+ */
+const Video = memo((props: VideoProps) => {
+  const { play, source, className, ...videoProps } = props
+  const ref = useRef<HTMLVideoElement>(null)
+
+  useEffect(() => {
+    if (!ref.current || typeof play !== 'boolean') {
+      return
+    }
+
+    const video = ref.current
+    const isPlaying = video.currentTime > 0 && !video.paused && !video.ended && video.readyState > video.HAVE_CURRENT_DATA
+
+    if (play) {
+      if (isPlaying) return
+      const playVideo = async () => {
+        try {
+          await video.play()
+        } catch (err) {
+          if (err instanceof Error && err.name === 'AbortError') {
+            video.muted = true
+            try {
+              await video.play()
+            } catch (retryErr) {
+              console.error('Could not play video:', retryErr)
+            }
+          } else {
+            console.error('Could not play video:', err)
+          }
+        }
+      }
+      playVideo()
+    } else {
+      if (!isPlaying) return
+      video.pause()
+    }
+  }, [play, source])
+
+  return <video {...videoProps} ref={ref} src={source} className={className} />
+})
+
+export { Video }

--- a/src/components/Video/Video.types.ts
+++ b/src/components/Video/Video.types.ts
@@ -1,0 +1,14 @@
+import { HTMLProps } from 'react'
+
+// `ref` is omitted from the public props: the component manages its own internal
+// ref to drive playback, and `HTMLProps`' legacy `ref` (which allows string refs)
+// is incompatible with the library's strict React types.
+type VideoProps = Omit<HTMLProps<HTMLVideoElement>, 'ref'> & {
+  /** Imperatively play/pause the video. Leave undefined to control it via native attributes. */
+  play?: boolean
+  playsInline?: boolean
+  /** Video source URL. Forwarded to the `src` attribute. */
+  source?: string
+}
+
+export type { VideoProps }

--- a/src/components/Video/index.ts
+++ b/src/components/Video/index.ts
@@ -1,0 +1,2 @@
+export { Video } from './Video'
+export type { VideoProps } from './Video.types'

--- a/src/index.ts
+++ b/src/index.ts
@@ -193,6 +193,7 @@ export * from './components/EventCard'
 export * from './components/EventSmallCard'
 export * from './components/ScenesTable'
 export * from './components/Badges'
+export * from './components/Video'
 export * as dclTable from './components/Table'
 
 export * as dclNetworkUtils from './lib/network'


### PR DESCRIPTION
Adds a thin, autoplay-safe wrapper over a native `<video>`. Consuming apps (sites) hand-roll this same element to drive background/hero videos; this promotes it into the shared library.

Behavior:
- When `play` is a boolean, the component imperatively plays/pauses the element.
- If the browser blocks autoplay with sound, it retries muted before giving up (the common mobile/Safari autoplay-policy failure).
- Leave `play` undefined to fall back to native attribute control (`autoPlay`, `controls`, …). All other props are forwarded to the underlying `<video>`.

`ref` is intentionally omitted from the public props: the component keeps its own internal ref to control playback, and `HTMLProps`' legacy string-ref type is incompatible with the library's strict React config.

Public API (`Video`, `VideoProps`) exported through `src/index.ts`. Additive; no existing component or type changed. It currently has 2 in-app consumers (`Create/Earn`, `Create/Hero`), and covers a gap ui2's `AssetPreviewPlayer`/`Media` don't (a bare autoplay-safe video element).

Verified locally: prettier, eslint, lint:package-json, `tsc` build (strict) and the jest suite all pass. Storybook stories added (`Decentraland UI/Video`): native controls and imperative `play`.