### PR TITLE
feat: stop demarcating districts on the atlas

### DIFF
--- a/src/components/Atlas/Atlas.tsx
+++ b/src/components/Atlas/Atlas.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import type { Layer, TileMapProps } from 'react-tile-map'
 import CircularProgress from '@mui/material/CircularProgress'
-import { getColorByType, getTiles } from './util'
+import { getTileLayer, getTiles } from './util'
 import { createLazyComponent } from '../../utils/optionalDependency'
 import { AtlasColor, AtlasProps, AtlasStateProps } from './Atlas.types'
 
@@ -32,13 +32,7 @@ const Atlas = React.memo((props: AtlasProps) => {
     (x: number, y: number) => {
       const id = x + ',' + y
       if (resolvedTiles && id in resolvedTiles) {
-        const tile = resolvedTiles[id]
-        return {
-          color: getColorByType(tile.type),
-          top: tile.top,
-          left: tile.left,
-          topLeft: tile.topLeft
-        }
+        return getTileLayer(resolvedTiles[id], resolvedTiles)
       } else {
         return {
           color: (x + y) % 2 === 0 ? AtlasColor.ODD : AtlasColor.EVEN

--- a/src/components/Atlas/Atlas.types.ts
+++ b/src/components/Atlas/Atlas.types.ts
@@ -5,7 +5,6 @@ enum AtlasColor {
   UNOWNED = '#09080A',
   PLAZA = '#70AC76',
   ROAD = '#716C7A',
-  DISTRICT = '#5054D4',
   ODD = '#110E13',
   EVEN = '#0D0B0E'
 }

--- a/src/components/Atlas/util.test.ts
+++ b/src/components/Atlas/util.test.ts
@@ -1,5 +1,92 @@
-describe('silly test', () => {
-  it('silly test', () => {
-    expect(true).toBe(true)
+import { getColorByType, getTileLayer } from './util'
+import { AtlasColor, AtlasTileProps, AtlasTileType } from './Atlas.types'
+
+const buildTile = (tile: Partial<AtlasTileProps> = {}): AtlasTileProps => ({
+  x: 0,
+  y: 0,
+  updatedAt: 0,
+  type: AtlasTileType.OWNED,
+  owner: '0xowner',
+  ...tile
+})
+
+const buildTiles = (tiles: AtlasTileProps[]): Record<string, AtlasTileProps> =>
+  tiles.reduce<Record<string, AtlasTileProps>>((acc, tile) => {
+    acc[tile.x + ',' + tile.y] = tile
+    return acc
+  }, {})
+
+describe('getColorByType', () => {
+  it('should paint an owned tile with the owned color', () => {
+    expect(getColorByType(AtlasTileType.OWNED)).toBe(AtlasColor.OWNED)
+  })
+
+  it('should paint an unowned tile with the unowned color', () => {
+    expect(getColorByType(AtlasTileType.UNOWNED)).toBe(AtlasColor.UNOWNED)
+  })
+
+  it('should keep plazas and roads with their own colors', () => {
+    expect(getColorByType(AtlasTileType.PLAZA)).toBe(AtlasColor.PLAZA)
+    expect(getColorByType(AtlasTileType.ROAD)).toBe(AtlasColor.ROAD)
+  })
+
+  it('should paint a district tile as the LAND it is instead of demarcating it', () => {
+    expect(getColorByType(AtlasTileType.DISTRICT, '0xowner')).toBe(AtlasColor.OWNED)
+    expect(getColorByType(AtlasTileType.DISTRICT)).toBe(AtlasColor.UNOWNED)
+  })
+})
+
+describe('getTileLayer', () => {
+  describe('when the tile is not a district', () => {
+    it('should keep the borders reported by the API', () => {
+      const tile = buildTile({ top: true, left: false, topLeft: true })
+
+      expect(getTileLayer(tile, buildTiles([tile]))).toEqual({
+        color: AtlasColor.OWNED,
+        top: true,
+        left: false,
+        topLeft: true
+      })
+    })
+  })
+
+  describe('when the tile is a district', () => {
+    it('should stitch it to the neighbours that belong to its estate', () => {
+      const tile = buildTile({
+        x: 0,
+        y: 0,
+        type: AtlasTileType.DISTRICT,
+        estateId: '1',
+        top: true,
+        left: true,
+        topLeft: true
+      })
+      const top = buildTile({ x: 0, y: 1, type: AtlasTileType.DISTRICT, estateId: '1' })
+      const left = buildTile({ x: -1, y: 0, type: AtlasTileType.DISTRICT, estateId: '2' })
+
+      expect(getTileLayer(tile, buildTiles([tile, top, left]))).toEqual({
+        color: AtlasColor.OWNED,
+        top: true,
+        left: false,
+        topLeft: false
+      })
+    })
+
+    it('should not stitch a district parcel that does not belong to an estate', () => {
+      const tile = buildTile({
+        type: AtlasTileType.DISTRICT,
+        top: true,
+        left: true,
+        topLeft: true
+      })
+      const top = buildTile({ x: 0, y: 1, type: AtlasTileType.DISTRICT })
+
+      expect(getTileLayer(tile, buildTiles([tile, top]))).toEqual({
+        color: AtlasColor.OWNED,
+        top: false,
+        left: false,
+        topLeft: false
+      })
+    })
   })
 })

--- a/src/components/Atlas/util.ts
+++ b/src/components/Atlas/util.ts
@@ -21,7 +21,7 @@ const getTiles = memo(
   { ttl: 10 * 60 * 1000 } // 10 minutes
 )
 
-const getColorByType = (type: AtlasTileType) => {
+const getColorByType = (type: AtlasTileType, owner?: string) => {
   switch (type) {
     case AtlasTileType.OWNED:
       return AtlasColor.OWNED
@@ -32,8 +32,33 @@ const getColorByType = (type: AtlasTileType) => {
     case AtlasTileType.ROAD:
       return AtlasColor.ROAD
     case AtlasTileType.DISTRICT:
-      return AtlasColor.DISTRICT
+      return owner ? AtlasColor.OWNED : AtlasColor.UNOWNED
   }
 }
 
-export { getTiles, getColorByType }
+const coordsToId = (x: number, y: number) => x + ',' + y
+
+const isSameEstate = (tile: AtlasTileProps, other?: AtlasTileProps) => !!tile.estateId && !!other && other.estateId === tile.estateId
+
+// Districts are drawn as the LAND they are, with borders recomputed per estate
+// instead of tracing the district outline.
+// See DAO proposal 9ee1965f-6a96-45f9-bb20-f60baa13607f.
+const getTileLayer = (tile: AtlasTileProps, tiles: Record<string, AtlasTileProps>) => {
+  if (tile.type !== AtlasTileType.DISTRICT) {
+    return {
+      color: getColorByType(tile.type),
+      top: tile.top,
+      left: tile.left,
+      topLeft: tile.topLeft
+    }
+  }
+
+  return {
+    color: getColorByType(tile.type, tile.owner),
+    top: isSameEstate(tile, tiles[coordsToId(tile.x, tile.y + 1)]),
+    left: isSameEstate(tile, tiles[coordsToId(tile.x - 1, tile.y)]),
+    topLeft: isSameEstate(tile, tiles[coordsToId(tile.x - 1, tile.y + 1)])
+  }
+}
+
+export { getTiles, getColorByType, getTileLayer }


### PR DESCRIPTION
Enacts DAO proposal "Removing the 'District' demarcation on all Maps" (https://decentraland.org/governance/proposal/?id=9ee1965f-6a96-45f9-bb20-f60baa13607f)

District tiles are drawn as the LAND they are instead of the purple overlay, and their borders are recomputed against the estate each parcel belongs to.