### PR TITLE
feat: add shop credits balance to navbar

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  testPathIgnorePatterns: ['/node_modules/', '/dist/'],
   coverageProvider: 'v8',
   fakeTimers: {
     enableGlobally: true

--- a/src/components/Navbar/Credits.styled.ts
+++ b/src/components/Navbar/Credits.styled.ts
@@ -70,6 +70,12 @@ const CreditsTooltip = styled('div')({
   zIndex: 10
 })
 
+/** Shop credits chip — inherits the credits chip's hover/tooltip/focus/breakpoint sizing;
+ *  distinctness comes from the icon, not a second accent color. */
+const ShopCreditsBalanceButton = styled(CreditsBalanceButton)({
+  color: colors.neutral.softWhite
+})
+
 const NavbarManaBalancesGroup = styled('div')({
   display: 'flex',
   alignItems: 'center',
@@ -137,4 +143,11 @@ const NavbarBalancesStack = styled('div')({
   }
 })
 
-export { CreditsBalanceButton, CreditsTooltip, NavbarBalancesStack, NavbarManaBalanceButton, NavbarManaBalancesGroup }
+export {
+  CreditsBalanceButton,
+  CreditsTooltip,
+  NavbarBalancesStack,
+  NavbarManaBalanceButton,
+  NavbarManaBalancesGroup,
+  ShopCreditsBalanceButton
+}

--- a/src/components/Navbar/MIGRATION.md
+++ b/src/components/Navbar/MIGRATION.md
@@ -25,8 +25,11 @@ type NavbarProps = {
   onSelectChain?: (chain: ChainId) => void
   manaBalances?: Partial<Record<Network, number>>
   onClickBalance?: (network: Network) => void
+  showManaBalancesInNavbar?: boolean
   creditsBalance?: { balance: number; expiresAt: number }
   onClickCredits?: () => void
+  shopCreditsBalance?: number
+  onClickShopCredits?: () => void
   onToggleUserCard?: (isOpen: boolean) => void
   onClickSignIn: () => void
   onClickSignOut: () => void
@@ -71,6 +74,14 @@ Credits display is built into the Navbar. Pass the data:
 <Navbar creditsBalance={{ balance: 4200, expiresAt: Date.now() + 86400000 * 30 }} onClickCredits={() => navigateToCredits()} />
 ```
 
+### Shop Credits Balance
+
+Shop credits (the USD-pegged shop currency) render as a separate chip, distinct from marketplace credits. Pass whole credits — the consumer pre-converts (e.g. cents → credits); `undefined` hides the chip, `0` renders as "0". Like the MANA chips (and unlike marketplace credits), it has no hover tooltip:
+
+```tsx
+<Navbar shopCreditsBalance={500} onClickShopCredits={() => navigateToTopUp()} />
+```
+
 ### Chain Selector & MANA Balance
 
 These render inside the user card panel (not in the top bar):
@@ -83,6 +94,12 @@ These render inside the user card panel (not in the top bar):
   manaBalances={{ [Network.ETHEREUM]: 1234, [Network.MATIC]: 5678 }}
   onClickBalance={network => openAccount(network)}
 />
+```
+
+Set `showManaBalancesInNavbar` to render the MANA balances in the navbar top bar (next to the credits chips) instead of inside the user card panel:
+
+```tsx
+<Navbar showManaBalancesInNavbar manaBalances={{ [Network.MATIC]: 5678 }} />
 ```
 
 ### URLs

--- a/src/components/Navbar/Navbar.stories.tsx
+++ b/src/components/Navbar/Navbar.stories.tsx
@@ -238,6 +238,8 @@ const MarketplaceWithManaInNavbar: Story = {
     showManaBalancesInNavbar: true,
     creditsBalance: { balance: 4200, expiresAt: Date.now() + 86400000 * 30 },
     onClickCredits: () => console.log('Credits clicked'),
+    shopCreditsBalance: 500,
+    onClickShopCredits: () => console.log('Shop credits clicked'),
     onClickSignIn: () => console.log('Sign In clicked'),
     onClickSignOut: () => console.log('Sign Out clicked')
   },
@@ -256,6 +258,28 @@ const MarketplaceWithManaInNavbar: Story = {
       </>
     )
   }
+}
+
+// The shop's exact configuration: shop credits + Polygon MANA only, no marketplace credits.
+const ShopExample: Story = {
+  args: {
+    isSignedIn: true,
+    address: '0xe3fc7040653768efb2941a6c26fdb868ed36ca99',
+    avatar: exampleAvatar,
+    activePage: 'shop',
+    manaBalances: { [Network.MATIC]: 5678 },
+    showManaBalancesInNavbar: true,
+    shopCreditsBalance: 500,
+    onClickShopCredits: () => console.log('Shop credits clicked'),
+    onClickSignIn: () => console.log('Sign In clicked'),
+    onClickSignOut: () => console.log('Sign Out clicked')
+  },
+  render: args => (
+    <>
+      <Navbar {...args} />
+      <PageContent />
+    </>
+  )
 }
 
 const CustomI18n: Story = {
@@ -279,4 +303,4 @@ const CustomI18n: Story = {
   )
 }
 
-export { SignedOut, SignedIn, WithNotifications, MarketplaceExample, MarketplaceWithManaInNavbar, CustomI18n }
+export { SignedOut, SignedIn, WithNotifications, MarketplaceExample, MarketplaceWithManaInNavbar, ShopExample, CustomI18n }

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -1,7 +1,7 @@
 import { memo, useCallback, useEffect, useRef, useState } from 'react'
 import { Network } from '@dcl/schemas/dist/dapps/network'
 import { formatBalance } from './formatBalance'
-import { CloseIcon, DclLogo, HamburgerIcon, ManaEthInlineIcon, ManaMaticInlineIcon } from './icons'
+import { CloseIcon, DclLogo, HamburgerIcon, ManaEthInlineIcon, ManaMaticInlineIcon, ShopCreditsIcon } from './icons'
 import { MobileMenu } from './MobileMenu'
 import { DEFAULT_I18N } from './Navbar.defaults'
 import { NavLinks } from './NavLinks'
@@ -13,7 +13,8 @@ import {
   CreditsTooltip,
   NavbarBalancesStack,
   NavbarManaBalanceButton,
-  NavbarManaBalancesGroup
+  NavbarManaBalancesGroup,
+  ShopCreditsBalanceButton
 } from './Credits.styled'
 import { HamburgerButton, LogoLink, NavbarLeft, NavbarRight, NavbarRightGroup, NavbarRoot, SignInButton } from './Navbar.styled'
 import type { DropdownSection } from './Navbar.defaults'
@@ -40,6 +41,8 @@ const Navbar = memo(function Navbar({
   showManaBalancesInNavbar = false,
   creditsBalance,
   onClickCredits,
+  shopCreditsBalance,
+  onClickShopCredits,
   activePage,
   onToggleUserCard,
   onClickSignIn,
@@ -170,7 +173,7 @@ const Navbar = memo(function Navbar({
         <NavbarRight>
           {isSignedIn && (
             <NavbarRightGroup>
-              {(creditsBalance || (showManaBalancesInNavbar && manaBalances)) && (
+              {(creditsBalance || shopCreditsBalance !== undefined || (showManaBalancesInNavbar && manaBalances)) && (
                 <NavbarBalancesStack>
                   {creditsBalance && (
                     <CreditsBalanceButton onClick={onClickCredits} aria-label={`${formatBalance(creditsBalance.balance)} credits`}>
@@ -207,6 +210,13 @@ const Navbar = memo(function Navbar({
                         </NavbarManaBalanceButton>
                       )}
                     </NavbarManaBalancesGroup>
+                  )}
+
+                  {shopCreditsBalance !== undefined && (
+                    <ShopCreditsBalanceButton onClick={onClickShopCredits} aria-label={`${formatBalance(shopCreditsBalance)} shop credits`}>
+                      <ShopCreditsIcon />
+                      {formatBalance(shopCreditsBalance)}
+                    </ShopCreditsBalanceButton>
                   )}
                 </NavbarBalancesStack>
               )}

--- a/src/components/Navbar/Navbar.types.ts
+++ b/src/components/Navbar/Navbar.types.ts
@@ -57,6 +57,11 @@ type NavbarProps = {
   creditsBalance?: { balance: number; expiresAt: number }
   /** Called when the user clicks the credits balance */
   onClickCredits?: () => void
+  /** Shop credits balance (whole credits) to display in the navbar top bar.
+   *  Consumer pre-converts (e.g. cents -> credits). undefined hides the chip. */
+  shopCreditsBalance?: number
+  /** Called when the user clicks the shop credits balance (e.g. open the top-up flow) */
+  onClickShopCredits?: () => void
   /** Called when the user card panel is toggled open or closed.
    *  Consumers can use this to close other panels (e.g. notifications). */
   onToggleUserCard?: (isOpen: boolean) => void

--- a/src/components/Navbar/formatBalance.spec.ts
+++ b/src/components/Navbar/formatBalance.spec.ts
@@ -1,0 +1,16 @@
+import { formatBalance } from './formatBalance'
+
+describe('formatBalance', () => {
+  it('groups thousands with commas', () => {
+    expect(formatBalance(1234)).toBe('1,234')
+    expect(formatBalance(5500000)).toBe('5,500,000')
+  })
+
+  it('floors decimals', () => {
+    expect(formatBalance(1234.99)).toBe('1,234')
+  })
+
+  it('renders zero', () => {
+    expect(formatBalance(0)).toBe('0')
+  })
+})

--- a/src/components/Navbar/icons.tsx
+++ b/src/components/Navbar/icons.tsx
@@ -454,6 +454,24 @@ const ManaMaticInlineIcon = memo(function ManaMaticInlineIcon(props: IconProps) 
   )
 })
 
+/** Hexagonal "C" badge for the shop's USD-pegged credits (ported from the shop's credits.svg).
+ *  Drawn in currentColor so the chip's CSS color drives it. */
+const ShopCreditsIcon = memo(function ShopCreditsIcon(props: IconProps) {
+  return (
+    <svg width="20" height="20" viewBox="0 0 20 21" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path
+        d="M13.1318 0.891714L18.5 6.29015V14.0226L13.125 19.5831H6.26758L0.891602 14.0216V6.29113L6.26074 0.891714H13.1318Z"
+        stroke="currentColor"
+        strokeWidth="1.78379"
+      />
+      <path
+        d="M7.81758 5.13837C8.7606 4.70684 9.80743 4.55428 10.8344 4.69871C11.8613 4.84315 12.8255 5.27853 13.6129 5.95344L12.0562 7.76966C11.6155 7.39196 11.076 7.1483 10.5012 7.06747C9.92652 6.98664 9.34068 7.07201 8.81294 7.31351C8.28519 7.555 7.8376 7.94253 7.52307 8.43029C7.20854 8.91805 7.0402 9.48566 7.03796 10.066C7.03572 10.6464 7.19967 11.2153 7.51042 11.7054C7.82117 12.1956 8.26576 12.5866 8.79162 12.8322C9.31748 13.0777 9.90265 13.1676 10.478 13.0912C11.0533 13.0148 11.5947 12.7753 12.0383 12.4011L13.581 14.2293C12.7884 14.8981 11.8209 15.326 10.7928 15.4625C9.7648 15.599 8.71916 15.4384 7.7795 14.9996C6.83984 14.5608 6.04542 13.8621 5.49014 12.9863C4.93485 12.1104 4.64191 11.0938 4.64592 10.0568C4.64992 9.01972 4.95071 8.00549 5.51274 7.13393C6.07478 6.26236 6.87456 5.5699 7.81758 5.13837Z"
+        fill="currentColor"
+      />
+    </svg>
+  )
+})
+
 export {
   AccountIcon,
   BellIcon,
@@ -472,6 +490,7 @@ export {
   NavbarCreditsIcon,
   PolygonChainIcon,
   SettingsIcon,
+  ShopCreditsIcon,
   ShoppingBagIcon,
   WearableIcon
 }


### PR DESCRIPTION
Adds a shop credits chip to the navbar next to the existing marketplace credits and MANA balances, for decentraland/shop#206.

- New optional props: `shopCreditsBalance?: number` (whole credits, consumer pre-converts; `undefined` hides the chip, `0` renders as \"0\") and `onClickShopCredits?: () => void`.
- Shop credits are USD-pegged with no expiry, so the existing `creditsBalance` prop (MANA-denominated, expiry tooltip) is untouched; reusing it would show a factually wrong tooltip.
- The chip carries no hover tooltip, matching the MANA chips.
- New `ShopCreditsIcon` (hexagon-C, currentColor) keeps the three balance types visually distinct.
- Stories: all three balances together in `MarketplaceWithManaInNavbar`, plus `ShopExample` mirroring the shop's exact configuration (shop credits + Polygon MANA only).
- `MIGRATION.md` documents the new props and the previously undocumented `showManaBalancesInNavbar`.
- Jest now ignores `dist/`, so the documented build → test pipeline order passes locally.

Chip order and color are defaults pending design sign-off. Consumer wiring lands separately in decentraland-dapps (derivation from the credits response's `usd` block) and the shop.