### PR TITLE
fix: stop mutating the shared user agent cache and serve intel macs the universal launcher

### DIFF
--- a/src/components/DownloadButton/DownloadButton.tsx
+++ b/src/components/DownloadButton/DownloadButton.tsx
@@ -1,11 +1,11 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import { AdvancedNavigatorUAData, useAdvancedUserAgentData } from '@dcl/hooks'
 import Download from '@mui/icons-material/Download'
 import { config } from '../../config'
 import { CDNSource, getCDNRelease } from '../../modules/cdnReleases'
 import { triggerFileDownload } from '../../modules/file'
 import { addQueryParamsToUrlString, updateUrlWithLastValue } from '../../modules/url'
-import { setUserAgentArchitectureDefaultByOs } from '../../modules/userAgent'
+import { resolveUserAgentDataForOs } from '../../modules/userAgent'
 import { DownloadButtonProps, DownloadOption, OperativeSystem } from './DownloadButton.types'
 import {
   DownloadButtonAppleIcon,
@@ -58,17 +58,19 @@ const DownloadButton = React.memo((props: DownloadButtonProps) => {
   } = props
   const [isDownloading, setIsDownloading] = useState(false)
 
-  const [isLoadingUserAgentData, userAgentData] = useAdvancedUserAgentData()
+  const [isLoadingUserAgentData, detectedUserAgentData] = useAdvancedUserAgentData()
 
   const windowSearchParams = typeof window !== 'undefined' ? new URLSearchParams(window.location.search) : undefined
   const searchParams = new URLSearchParams(windowSearchParams)
   const os = searchParams.get('os')
 
-  useEffect(() => {
-    if (userAgentData && os) {
-      setUserAgentArchitectureDefaultByOs(userAgentData, os as OperativeSystem)
-    }
-  }, [userAgentData, os])
+  // `?os=` (the "Also available on…" links) is an explicit platform request, so
+  // it overrides detection — but by deriving a new object, never by mutating the
+  // one `useAdvancedUserAgentData` hands out. That object is a module-level cache
+  // shared by every consumer in the session; mutating it leaked the override
+  // everywhere with no way back, and left this component's memoized icon and
+  // href on the old platform while the click handler used the new one.
+  const userAgentData = useMemo(() => resolveUserAgentDataForOs(detectedUserAgentData, os), [detectedUserAgentData, os])
 
   const defaultDownloadOption: DownloadOption | null = useMemo(() => {
     const links = cdnLinks || getCDNRelease(CDNSource.LAUNCHER)

--- a/src/modules/cdnReleases.spec.ts
+++ b/src/modules/cdnReleases.spec.ts
@@ -1,0 +1,54 @@
+// The real config module loads JSON env files through @dcl/ui-env, which is ESM
+// and unloadable under this repo's node-environment jest.
+jest.mock('../config', () => ({
+  config: { get: () => 'https://download-gateway.decentraland.org' }
+}))
+
+import { CDNSource, getCDNRelease } from './cdnReleases'
+
+describe('getCDNRelease', () => {
+  describe('when resolving the macOS builds', () => {
+    // The published dmg is a universal binary (`lipo -archs` → `x86_64 arm64`).
+    // Intel used to be pointed at the legacy Electron build named "Decentraland
+    // Outdated" instead, and that cohort never converted. These assertions exist
+    // so the two architectures cannot silently drift apart again.
+    it('should serve Intel and Apple Silicon the same universal artifact', () => {
+      const links = getCDNRelease(CDNSource.LAUNCHER)
+
+      expect(links?.macOS.amd64).toBe(links?.macOS.arm64)
+    })
+
+    it('should serve the same universal artifact on the identity-bound source', () => {
+      const links = getCDNRelease(CDNSource.AUTO_SIGNING, 'identity-123')
+
+      expect(links?.macOS.amd64).toBe(links?.macOS.arm64)
+    })
+
+    it('should never point at the legacy Outdated build', () => {
+      for (const source of [CDNSource.LAUNCHER, CDNSource.AUTO_SIGNING]) {
+        const links = getCDNRelease(source, 'identity-123')
+
+        expect(links?.macOS.amd64).not.toMatch(/Outdated/i)
+        expect(links?.macOS.arm64).not.toMatch(/Outdated/i)
+      }
+    })
+
+    it('should bake the identity into both architectures on the identity-bound source', () => {
+      const links = getCDNRelease(CDNSource.AUTO_SIGNING, 'identity-123')
+
+      // Intel downloads must stay attributable: an un-baked CDN URL would drop
+      // the id the launcher forwards into the funnel.
+      expect(links?.macOS.amd64).toContain('identity-123')
+      expect(links?.macOS.arm64).toContain('identity-123')
+      expect(links?.macOS.amd64).not.toContain(':identityId')
+    })
+  })
+
+  describe('when resolving the Windows build', () => {
+    it('should return the launcher installer', () => {
+      const links = getCDNRelease(CDNSource.LAUNCHER)
+
+      expect(links?.Windows.amd64).toContain('Decentraland_installer.exe')
+    })
+  })
+})

--- a/src/modules/cdnReleases.ts
+++ b/src/modules/cdnReleases.ts
@@ -1,4 +1,8 @@
-import { OperativeSystem } from '../components/DownloadButton'
+// Imported from the types module rather than the component barrel: the barrel
+// pulls DownloadButton (and React) back into this module's graph, which is both
+// a cycle (DownloadButton imports this file) and what made this module
+// impossible to unit test.
+import { OperativeSystem } from '../components/DownloadButton/DownloadButton.types'
 import { config } from '../config'
 
 enum CDNSource {
@@ -19,8 +23,20 @@ type CDNConfig = {
   }
 }
 const LAUNCHER_BASE_URL = 'https://explorer-artifacts.decentraland.org/launcher-rust'
-const LAUNCHER_LEGACY_BASE_URL = 'https://explorer-artifacts.decentraland.org/launcher/dcl'
 const AUTO_SIGNING_BASE_URL = config.get('AUTO_SIGNING_BASE_URL')
+
+// The macOS launcher dmg is a UNIVERSAL binary — verified 2026-08-03, `lipo
+// -archs` on the published artifact reports `x86_64 arm64` — so Intel and Apple
+// Silicon are served the same file and both run it natively. Intel used to be
+// pointed at the legacy Electron build named "Decentraland Outdated", which is
+// why that cohort never converted: 9 anons in July 2026, zero of whom reached
+// the world. Keep both architectures on one constant so they cannot drift apart
+// again.
+const LAUNCHER_MACOS_DMG = `${LAUNCHER_BASE_URL}/Decentraland_installer.dmg`
+// Identity-bound variant: the gateway bakes the attribution id into the same
+// universal installer, so Intel must use it too or those downloads become
+// unattributable in the funnel.
+const AUTO_SIGNING_MACOS_DMG = `${AUTO_SIGNING_BASE_URL}/:identityId/decentraland.dmg`
 
 const CDN_CONFIGS: Record<CDNSource, CDNConfig> = {
   [CDNSource.LAUNCHER]: {
@@ -29,8 +45,8 @@ const CDN_CONFIGS: Record<CDNSource, CDNConfig> = {
         amd64: `${LAUNCHER_BASE_URL}/Decentraland_installer.exe`
       },
       [OperativeSystem.MACOS]: {
-        amd64: `${LAUNCHER_LEGACY_BASE_URL}/Decentraland%20Outdated-mac-x64.dmg`,
-        arm64: `${LAUNCHER_BASE_URL}/Decentraland_installer.dmg`
+        amd64: LAUNCHER_MACOS_DMG,
+        arm64: LAUNCHER_MACOS_DMG
       }
     }
   },
@@ -40,8 +56,8 @@ const CDN_CONFIGS: Record<CDNSource, CDNConfig> = {
         amd64: `${AUTO_SIGNING_BASE_URL}/:identityId/decentraland.exe`
       },
       [OperativeSystem.MACOS]: {
-        amd64: `${LAUNCHER_LEGACY_BASE_URL}/Decentraland%20Outdated-mac-x64.dmg`,
-        arm64: `${AUTO_SIGNING_BASE_URL}/:identityId/decentraland.dmg`
+        amd64: AUTO_SIGNING_MACOS_DMG,
+        arm64: AUTO_SIGNING_MACOS_DMG
       }
     }
   }

--- a/src/modules/userAgent.spec.ts
+++ b/src/modules/userAgent.spec.ts
@@ -1,0 +1,94 @@
+import { AdvancedNavigatorUAData } from '@dcl/hooks'
+import { resolveUserAgentDataForOs } from './userAgent'
+import { OperativeSystem } from '../components/DownloadButton/DownloadButton.types'
+
+const buildUserAgentData = (overrides: Partial<AdvancedNavigatorUAData> = {}): AdvancedNavigatorUAData => ({
+  browser: { name: 'Safari', version: '17.0' },
+  engine: { name: 'WebKit', version: '605.1' },
+  os: { name: OperativeSystem.MACOS, version: '14.0' },
+  cpu: { architecture: 'arm64' },
+  mobile: false,
+  tablet: false,
+  ...overrides
+})
+
+describe('resolveUserAgentDataForOs', () => {
+  describe('when no operative system is requested', () => {
+    it('should return the same reference so callers can memoize on it', () => {
+      const userAgent = buildUserAgentData()
+
+      expect(resolveUserAgentDataForOs(userAgent, null)).toBe(userAgent)
+      expect(resolveUserAgentDataForOs(userAgent, undefined)).toBe(userAgent)
+      expect(resolveUserAgentDataForOs(userAgent, '')).toBe(userAgent)
+    })
+  })
+
+  describe('when the requested operative system is not one we publish', () => {
+    it('should return the same reference', () => {
+      const userAgent = buildUserAgentData()
+
+      expect(resolveUserAgentDataForOs(userAgent, 'Linux')).toBe(userAgent)
+      expect(resolveUserAgentDataForOs(userAgent, 'windows')).toBe(userAgent)
+    })
+  })
+
+  describe('when the requested operative system is the one already detected', () => {
+    it('should return the same reference', () => {
+      const userAgent = buildUserAgentData()
+
+      expect(resolveUserAgentDataForOs(userAgent, OperativeSystem.MACOS)).toBe(userAgent)
+    })
+  })
+
+  describe('when there is no user agent data yet', () => {
+    it('should return undefined', () => {
+      expect(resolveUserAgentDataForOs(undefined, OperativeSystem.WINDOWS)).toBeUndefined()
+    })
+  })
+
+  describe('when Windows is requested from a macOS visitor', () => {
+    it('should report Windows on the published amd64 architecture', () => {
+      const result = resolveUserAgentDataForOs(buildUserAgentData(), OperativeSystem.WINDOWS)
+
+      expect(result?.os.name).toBe(OperativeSystem.WINDOWS)
+      expect(result?.cpu.architecture).toBe('amd64')
+    })
+
+    it('should not mutate the input, which is a cache shared across the session', () => {
+      const userAgent = buildUserAgentData()
+
+      resolveUserAgentDataForOs(userAgent, OperativeSystem.WINDOWS)
+
+      expect(userAgent.os.name).toBe(OperativeSystem.MACOS)
+      expect(userAgent.cpu.architecture).toBe('arm64')
+    })
+
+    it('should preserve every unrelated field', () => {
+      const userAgent = buildUserAgentData({ mobile: true, tablet: true })
+
+      const result = resolveUserAgentDataForOs(userAgent, OperativeSystem.WINDOWS)
+
+      expect(result?.browser).toEqual(userAgent.browser)
+      expect(result?.engine).toEqual(userAgent.engine)
+      expect(result?.os.version).toBe(userAgent.os.version)
+      expect(result?.mobile).toBe(true)
+      expect(result?.tablet).toBe(true)
+    })
+  })
+
+  describe('when macOS is requested from a Windows visitor', () => {
+    it('should report macOS on arm64, the architecture the current installer is published for', () => {
+      const windowsUserAgent = buildUserAgentData({
+        os: { name: OperativeSystem.WINDOWS, version: '11' },
+        cpu: { architecture: 'amd64' }
+      })
+
+      const result = resolveUserAgentDataForOs(windowsUserAgent, OperativeSystem.MACOS)
+
+      expect(result?.os.name).toBe(OperativeSystem.MACOS)
+      // 'unknown' (the previous behavior) matched no published artifact, so the
+      // download silently degraded to opening the download page.
+      expect(result?.cpu.architecture).toBe('arm64')
+    })
+  })
+})

--- a/src/modules/userAgent.ts
+++ b/src/modules/userAgent.ts
@@ -1,6 +1,51 @@
 import { AdvancedNavigatorUAData } from '@dcl/hooks'
 import { OperativeSystem } from '../components/DownloadButton/DownloadButton.types'
 
+// The architecture each platform's current installer is published for. macOS
+// also has an `amd64` entry, but it points at the legacy Electron build named
+// "Decentraland Outdated" — never the target of an explicit `?os=macOS` request.
+const DEFAULT_ARCHITECTURE_BY_OS: Record<OperativeSystem, string> = {
+  [OperativeSystem.MACOS]: 'arm64',
+  [OperativeSystem.WINDOWS]: 'amd64'
+}
+
+const isSupportedOperativeSystem = (os: string | null | undefined): os is OperativeSystem =>
+  os === OperativeSystem.MACOS || os === OperativeSystem.WINDOWS
+
+/**
+ * Resolves the user-agent data to use for a platform the visitor explicitly
+ * asked for (the `?os=` query param behind the "Also available on…" links).
+ *
+ * Returns a NEW object — never mutates the input. The input is `@dcl/hooks`'
+ * module-level cache, shared by every component in the session: mutating it
+ * leaked the override into unrelated consumers with no way to undo it, and left
+ * memoized renders (icon, href) reading the pre-override values while the click
+ * handler read the post-override ones.
+ *
+ * The same reference is returned when there is nothing to override, so callers
+ * can safely use the result as a `useMemo` dependency.
+ */
+const resolveUserAgentDataForOs = (
+  userAgent: AdvancedNavigatorUAData | undefined,
+  os: string | null | undefined
+): AdvancedNavigatorUAData | undefined => {
+  if (!userAgent || !isSupportedOperativeSystem(os) || userAgent.os.name === os) {
+    return userAgent
+  }
+
+  return {
+    ...userAgent,
+    os: { ...userAgent.os, name: os },
+    cpu: { ...userAgent.cpu, architecture: DEFAULT_ARCHITECTURE_BY_OS[os] }
+  }
+}
+
+/**
+ * @deprecated Mutates the shared `@dcl/hooks` user-agent cache in place, and
+ * sets an `unknown` architecture for macOS that matches no published artifact
+ * (so the download silently degraded to opening the download page). Use
+ * `resolveUserAgentDataForOs`, which returns a new object.
+ */
 const setUserAgentArchitectureDefaultByOs = (userAgent: AdvancedNavigatorUAData, os: OperativeSystem): AdvancedNavigatorUAData => {
   if (os === OperativeSystem.MACOS) {
     userAgent.os.name = OperativeSystem.MACOS
@@ -12,4 +57,4 @@ const setUserAgentArchitectureDefaultByOs = (userAgent: AdvancedNavigatorUAData,
   return userAgent
 }
 
-export { setUserAgentArchitectureDefaultByOs }
+export { resolveUserAgentDataForOs, setUserAgentArchitectureDefaultByOs }


### PR DESCRIPTION
Two independent defects in the download path, found while auditing where the download funnel loses people.

## 1. `?os=` mutated a cache shared by the whole session

`DownloadButton` called `setUserAgentArchitectureDefaultByOs(userAgentData, os)` inside a `useEffect`. That function edits its argument in place, and the argument is `@dcl/hooks`' module-level `_cachedData` singleton, handed to every consumer in the session. Consequences:

- The mutation does not change the object reference, so the `useMemo` keyed on it never recomputes: the rendered icon and `href` stayed on the old platform while `handleClick`, which re-derives from the mutated object, delivered the new one. The button could show the Apple icon and download the `.exe`.
- The override leaked to every other component reading the hook, for the rest of the session, with no path back short of a full page load (the effect only runs when `os` is present).

Also, `?os=macOS` never actually delivered a macOS build: the function set `cpu.architecture = 'unknown'`, and no published artifact has an `unknown` key, so `createDownloadOption` returned `null` and the button silently degraded to reopening the download page.

Replaced with a pure `resolveUserAgentDataForOs`, which returns a new object (the same reference when there is nothing to override, so it stays memo-safe) and resolves macOS to `arm64`. The query param keeps overriding detection: that is the feature behind the "Also available on…" links and it is intentional. `setUserAgentArchitectureDefaultByOs` is kept and marked `@deprecated` rather than deleted, in case other consumers import it.

## 2. Intel Macs were served the legacy "Decentraland Outdated" build

`cdnReleases.ts` mapped macOS `amd64` to `Decentraland%20Outdated-mac-x64.dmg` (the old Electron launcher) while `arm64` got the current one.

The current launcher dmg is a **universal binary**, verified against the published artifact on 2026-08-03:

```
$ lipo -archs .../Decentraland.app/Contents/MacOS/dcl_launcher
x86_64 arm64
```

So Intel Macs run it natively and there is no reason for a separate legacy target. This matches what we measured: Intel Macs were a **100% dead end — 9 anons in July 2026, none of whom ever reached the world**. Both architectures now point at one constant so they cannot drift apart again, and on the identity-bound source both use the gateway URL, so Intel downloads keep the baked attribution id instead of falling back to a plain CDN link.

`LAUNCHER_LEGACY_BASE_URL` is removed (no remaining references).

### Incidental

`cdnReleases.ts` imported `OperativeSystem` from the `DownloadButton` barrel, which pulled the component and React back into this module's graph — a cycle (`DownloadButton` imports `cdnReleases`) and the reason the module could not be unit tested. Now imports from `DownloadButton.types` directly, matching what `userAgent.ts` already did.

### Verification

Tests are written as pure-function specs to fit this repo's `testEnvironment: 'node'` jest setup (no RTL): 13 new tests across `userAgent.spec.ts` and `cdnReleases.spec.ts`, including a guard that neither macOS architecture may ever point at an "Outdated" URL again.

- `npx jest` — 6 suites, 50 tests green
- `npx tsc --noEmit` clean
- `npm run lint` and prettier clean
