### PR TITLE
feat: point navbar shop menu at the shop and restore explore label

### DIFF
--- a/src/components/Navbar/Navbar.defaults.ts
+++ b/src/components/Navbar/Navbar.defaults.ts
@@ -4,7 +4,7 @@ import type { NavbarI18n } from './Navbar.types'
 const DEFAULT_I18N: NavbarI18n = {
   signIn: 'SIGN IN',
   signingIn: 'SIGNING IN...',
-  whatsOn: "What's On",
+  whatsOn: 'Explore',
   shop: 'Shop',
   shopAll: 'Shop All',
   wearables: 'Wearables',
@@ -56,12 +56,11 @@ type MenuConfig = {
  * environment (zone for dev, today for staging, org for production).
  */
 function buildMenuConfig(): MenuConfig {
-  const marketplaceUrl = config.get('MARKETPLACE_URL')
+  const shopUrl = config.get('SHOP_URL')
   const builderUrl = config.get('BUILDER_URL')
   const eventsUrl = config.get('EVENTS_URL')
   const createUrl = config.get('CREATE_URL')
   const blogUrl = config.get('BLOG_URL')
-  const namesUrl = config.get('MARKETPLACE_NAMES_URL')
   const landsUrl = config.get('MARKETPLACE_LANDS_URL')
 
   return {
@@ -72,10 +71,11 @@ function buildMenuConfig(): MenuConfig {
     shop: {
       label: 'shop',
       items: [
-        { label: 'shopAll', url: marketplaceUrl },
-        { label: 'wearables', url: `${marketplaceUrl}/browse?assetType=item&section=wearables&status=on_sale` },
-        { label: 'emotes', url: `${marketplaceUrl}/browse?assetType=item&section=emotes&status=on_sale` },
-        { label: 'names', url: namesUrl },
+        { label: 'shopAll', url: shopUrl },
+        { label: 'wearables', url: `${shopUrl}/items?category=wearable` },
+        { label: 'emotes', url: `${shopUrl}/items?category=emote` },
+        { label: 'names', url: `${shopUrl}/items?category=names` },
+        // LAND has no category in the shop, so it stays on the marketplace.
         { label: 'land', url: landsUrl },
         { label: 'merch', url: 'https://store.decentraland.org/', isExternal: true }
       ]

--- a/src/config/env/dev.json
+++ b/src/config/env/dev.json
@@ -3,6 +3,7 @@
   "ACCOUNT_URL": "https://decentraland.zone/account",
   "PROFILE_URL": "https://decentraland.zone/profile",
   "MARKETPLACE_URL": "https://decentraland.zone/marketplace",
+  "SHOP_URL": "https://decentraland.zone/shop",
   "BUILDER_URL": "https://decentraland.zone/builder",
   "DAO_URL": "https://decentraland.zone/dao",
   "GOVERNANCE_URL": "https://decentraland.zone/governance",

--- a/src/config/env/prod.json
+++ b/src/config/env/prod.json
@@ -3,6 +3,7 @@
   "ACCOUNT_URL": "https://decentraland.org/account",
   "PROFILE_URL": "https://decentraland.org/profile",
   "MARKETPLACE_URL": "https://decentraland.org/marketplace",
+  "SHOP_URL": "https://decentraland.org/shop",
   "BUILDER_URL": "https://decentraland.org/builder",
   "DAO_URL": "https://decentraland.org/dao",
   "GOVERNANCE_URL": "https://decentraland.org/governance",

--- a/src/config/env/stg.json
+++ b/src/config/env/stg.json
@@ -3,6 +3,7 @@
   "ACCOUNT_URL": "https://decentraland.today/account",
   "PROFILE_URL": "https://decentraland.today/profile",
   "MARKETPLACE_URL": "https://decentraland.today/marketplace",
+  "SHOP_URL": "https://decentraland.today/shop",
   "BUILDER_URL": "https://decentraland.today/builder",
   "DAO_URL": "https://decentraland.today/dao",
   "GOVERNANCE_URL": "https://decentraland.today/governance",


### PR DESCRIPTION
## Changes

- **Shop menu now points at the shop** (`decentraland.org/shop`) instead of the legacy marketplace. New `SHOP_URL` config key added to `dev`/`stg`/`prod` so it resolves per environment (`.zone` / `.today` / `.org`), matching how the other URLs work.
  - Shop All → `${SHOP_URL}`
  - Wearables → `${SHOP_URL}/items?category=wearable`
  - Emotes → `${SHOP_URL}/items?category=emote`
  - Names → `${SHOP_URL}/items?category=names`
  - **LAND and Merch are unchanged** — the shop has no LAND category, so LAND stays on `MARKETPLACE_LANDS_URL`.
- **Restores the `Explore` label.** #427 renamed it from "What's On" back in April, but #453 reintroduced the old string while adding the creator-documentation link, so the rename was silently undone and shipped in 3.15.0.

The `whatsOn` key itself is untouched — only the visible label changes, so `activePage="whatsOn"` and every existing consumer keep working (same approach #427 took).

`MARKETPLACE_NAMES_URL` is no longer read by the navbar but is kept in the env files: it is public config surface other consumers may rely on.

## Notes

The `?category=` params match the shop's own filter contract — its `/items` route reads every filter from the URL, and `all | wearable | emote | names` are the category keys it accepts. `status` is omitted because the shop already defaults to `on_sale`.

## Test plan

- [x] `npm run format`, `npm run lint:fix`, `npm run lint:package-json`, `npm run build`, `npm test` (37 passing)
- [ ] Verify each Shop menu entry lands on the right category in a consumer once bumped
- [ ] Confirm the navbar reads `Explore` in the Storybook navbar stories