### PR TITLE
fix: stop the wearable preview loading twice on mount

### DIFF
--- a/src/components/WearablePreview/WearablePreview.tsx
+++ b/src/components/WearablePreview/WearablePreview.tsx
@@ -3,11 +3,11 @@ import { PreviewMessagePayload, PreviewMessageType, PreviewOptions, sendMessage 
 import equal from 'deep-equal'
 import { createController } from './WearablePreview.controller'
 import { config } from '../../config'
-import { createDebounce } from '../../lib/debounce'
 import { WearablePreviewProps, WearablePreviewState } from './WearablePreview.types'
 import { StyledWearablePreview } from './WearablePreview.styled'
 
-const debounce = createDebounce()
+// How long prop changes are coalesced before being pushed to the iframe.
+const UPDATE_DEBOUNCE_MS = 500
 
 const safeEncodeParam = (key: string, value: unknown): string => {
   if (value === undefined || value === null || value === '') {
@@ -41,6 +41,10 @@ const WearablePreview = (props: WearablePreviewProps) => {
 
   const iframeRef = useRef<HTMLIFrameElement>(null)
   const lastOptionsRef = useRef<PreviewOptions | null>(null)
+  // The `src` built below encodes every option as a query param, so a freshly loaded document already
+  // has them applied. This holds the src those options were delivered by, so an update is only sent for
+  // what the URL did not already say (see the effect that seeds `lastOptionsRef`).
+  const deliveredUrlRef = useRef<string | null>(null)
 
   const url = useMemo(() => {
     const {
@@ -295,6 +299,17 @@ const WearablePreview = (props: WearablePreviewProps) => {
     }
   }, [handleMessage])
 
+  // Treat the options the current `src` encodes as already delivered. Without this the FIRST update is
+  // always dispatched — `sendUpdate` skips its comparison while `lastOptionsRef` is still empty — and it
+  // repeats what the URL had just said. The preview app rebuilds its scene from scratch on any update, so
+  // that redundant message costs a second full load: the avatar appears, vanishes and loads again. A
+  // `blob` is the exception, since it cannot travel in a query param.
+  useEffect(() => {
+    if (props.blob || deliveredUrlRef.current === url) return
+    deliveredUrlRef.current = url
+    lastOptionsRef.current = options
+  }, [url, options, props.blob])
+
   useEffect(() => {
     // if there's a blob in the props, it can't be passed via URL, so we send it via postMessage
     if (props.blob) {
@@ -302,8 +317,12 @@ const WearablePreview = (props: WearablePreviewProps) => {
     }
   }, [props.blob, handleUpdate])
 
+  // Debounced per instance. A module-level timer gave every WearablePreview on the page one shared slot,
+  // so two previews cancelled each other's pending update and the survivor was pushed out by each
+  // unrelated render. Cleared on unmount too, so an update can't fire against a detached iframe.
   useEffect(() => {
-    debounce(handleUpdate, 500)
+    const timeout = setTimeout(handleUpdate, UPDATE_DEBOUNCE_MS)
+    return () => clearTimeout(timeout)
   }, [handleUpdate])
 
   if (props.tokenId && props.itemId) {


### PR DESCRIPTION
Every `WearablePreview` mount dispatched one redundant `UPDATE` postMessage that repeated what the iframe's `src` had already delivered. The preview app rebuilds its scene from scratch on any update, so that message cost a second full load — a new WebGL context, the GLBs fetched again, and the avatar blinking out and back in after it had already rendered.

Two things caused it:

- `sendUpdate` skips its equality check while `lastOptionsRef` is still empty (`!currentLastOptions || …`), so the first update was always sent even though the URL had just carried those exact options.
- The debounce was a module-level `createDebounce()`, i.e. one shared timer for every `WearablePreview` on the page. Instances cancelled each other's pending update, and since `handleUpdate` is rebuilt on each render (`options` is memoized on the freshly-spread `restProps`), any unrelated render pushed the survivor further out. On a page with two previews it landed ~2.9s after mount — well after the avatar was on screen, which is what turned an invisible race into a visible reload.

## Changes

- Record the options the current `src` encodes as already delivered, so an update is only sent for what the URL did not already say. A `blob` is exempt, since it cannot travel in a query param and still has to go through the message channel.
- Debounce per instance instead of per module, and clear the timer on unmount so a pending update can't fire against a detached iframe.

Genuine prop changes are unaffected: a change that alters the `src` re-seeds the snapshot as the iframe reloads with it (so a urn toggle no longer pays a reload *and* a redundant update), and a change the URL cannot express is still detected against that snapshot and sent.

## Test plan

Measured on an avatar preview with two `WearablePreview` instances mounted, instrumenting the postMessage traffic, every `getContext('webgl2')` call and the canvas visibility class inside the iframe.

Before — the avatar renders, then the redundant update arrives and it reloads:

```
4176ms  webgl context #1
4271ms  VISIBLE
6839ms  RECV UPDATE (same values the src already had)
7016ms  HIDDEN          <- ~330ms blackout, 2.7s after it had loaded
7138ms  webgl context #2
7344ms  VISIBLE
```

After, same page:

```
4834ms  webgl context #1
4968ms  VISIBLE         <- stays; no update sent, no second context
```

- [x] one WebGL context and one load per preview instead of two
- [x] no update dispatched when the `src` already carries the options
- [x] `format`, `lint:fix`, `lint:package-json`, `build`, `test` all green

`src/lib/debounce.ts` is now unreferenced. It is not part of the public API in `src/index.ts`, but it is reachable as a deep import from `dist/`, so this leaves it in place rather than deleting it — happy to drop it if you'd rather.

Component tests are not included: `jest.config.js` runs on `testEnvironment: 'node'` with no jsdom or RTL, so the existing specs are all pure helpers. Covering this behaviour needs that harness added first, which felt like its own change.