### PR TITLE
feat: add banner stories and move the contentful cdn to cms-api

### DIFF
--- a/src/components/Banner/Banner.stories.tsx
+++ b/src/components/Banner/Banner.stories.tsx
@@ -1,0 +1,172 @@
+import { BLOCKS } from '@contentful/rich-text-types'
+import { ContentfulLocale } from '@dcl/schemas'
+import { Banner } from './Banner'
+import bannerBackground from '../../Assets/custom-welcome-background.webp'
+import bannerLogo from '../../Assets/dcl-logo-qr.svg'
+import type { Document } from '@contentful/rich-text-types'
+import type { AlignmentFieldType, BannerFields, ContentfulAsset, LocalizedField, SysLink } from '@dcl/schemas'
+import type { Meta, StoryObj } from '@storybook/react'
+
+const BACKGROUND_ASSET_ID = 'story-banner-background'
+const LOGO_ASSET_ID = 'story-banner-logo'
+
+// Bundled assets resolve to a relative path, and getAssetUrl only leaves the url untouched when it is already absolute.
+const toAbsoluteUrl = (path: string) => new URL(path, window.location.href).href
+
+function localized<T>(value: T): LocalizedField<T> {
+  return { [ContentfulLocale.enUS]: value }
+}
+
+const assetLink = (id: string): SysLink<'Asset'> => ({
+  sys: { type: 'Link', linkType: 'Asset', id }
+})
+
+const buildAsset = (id: string, url: string, contentType: string): ContentfulAsset => ({
+  metadata: { tags: [], concepts: [] },
+  sys: {
+    space: { sys: { type: 'Link', linkType: 'Space', id: 'story-space' } },
+    id,
+    type: 'Asset',
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    environment: { sys: { type: 'Link', linkType: 'Environment', id: 'master' } },
+    publishedVersion: 1,
+    revision: 1
+  },
+  fields: {
+    title: localized(id),
+    description: localized(''),
+    file: localized({ url, details: { size: 0 }, fileName: id, contentType })
+  }
+})
+
+const richText = (value: string): Document => ({
+  nodeType: BLOCKS.DOCUMENT,
+  data: {},
+  content: [
+    {
+      nodeType: BLOCKS.PARAGRAPH,
+      data: {},
+      content: [{ nodeType: 'text', value, marks: [], data: {} }]
+    }
+  ]
+})
+
+const assets: Record<string, ContentfulAsset> = {
+  [BACKGROUND_ASSET_ID]: buildAsset(BACKGROUND_ASSET_ID, toAbsoluteUrl(bannerBackground), 'image/webp'),
+  [LOGO_ASSET_ID]: buildAsset(LOGO_ASSET_ID, toAbsoluteUrl(bannerLogo), 'image/svg+xml')
+}
+
+const baseFields: BannerFields = {
+  desktopTitle: localized('Step into Decentraland'),
+  desktopTitleAlignment: localized<AlignmentFieldType>('Left'),
+  mobileTitle: localized('Step into Decentraland'),
+  mobileTitleAlignment: localized<AlignmentFieldType>('Center'),
+  desktopText: localized(richText('Explore worlds, collect wearables and join live events built by the community.')),
+  desktopTextAlignment: localized<AlignmentFieldType>('Left'),
+  mobileText: localized(richText('Explore worlds, collect wearables and join live events.')),
+  mobileTextAlignment: localized<AlignmentFieldType>('Center'),
+  showButton: localized(true),
+  buttonLink: localized('https://decentraland.org/download/'),
+  buttonsText: localized('Explore now'),
+  desktopButtonAlignment: localized<AlignmentFieldType>('Left'),
+  mobileButtonAlignment: localized<AlignmentFieldType>('Center'),
+  fullSizeBackground: localized(assetLink(BACKGROUND_ASSET_ID)),
+  mobileBackground: localized(assetLink(BACKGROUND_ASSET_ID)),
+  logo: localized(assetLink(LOGO_ASSET_ID))
+}
+
+const meta = {
+  title: 'Decentraland UI/Banner',
+  component: Banner,
+  parameters: {
+    layout: 'fullscreen'
+  },
+  tags: ['autodocs'],
+  args: {
+    fields: baseFields,
+    assets,
+    isLoading: false,
+    error: null,
+    locale: ContentfulLocale.enUS
+  },
+  argTypes: {
+    locale: {
+      control: 'select',
+      options: Object.values(ContentfulLocale)
+    }
+  }
+} satisfies Meta<typeof Banner>
+
+type Story = StoryObj<typeof meta>
+
+const Default: Story = {}
+
+const WithoutLogo: Story = {
+  args: {
+    fields: { ...baseFields, logo: undefined }
+  }
+}
+
+const WithoutButton: Story = {
+  args: {
+    fields: { ...baseFields, showButton: localized(false) }
+  }
+}
+
+const CenteredContent: Story = {
+  args: {
+    fields: {
+      ...baseFields,
+      logo: undefined,
+      desktopTitleAlignment: localized<AlignmentFieldType>('Center'),
+      desktopTextAlignment: localized<AlignmentFieldType>('Center'),
+      desktopButtonAlignment: localized<AlignmentFieldType>('Center')
+    }
+  }
+}
+
+const RightAlignedContent: Story = {
+  args: {
+    fields: {
+      ...baseFields,
+      logo: undefined,
+      desktopTitleAlignment: localized<AlignmentFieldType>('Right'),
+      desktopTextAlignment: localized<AlignmentFieldType>('Right'),
+      desktopButtonAlignment: localized<AlignmentFieldType>('Right')
+    }
+  }
+}
+
+const Localized: Story = {
+  args: {
+    locale: ContentfulLocale.es,
+    fields: {
+      ...baseFields,
+      desktopTitle: { [ContentfulLocale.enUS]: 'Step into Decentraland', [ContentfulLocale.es]: 'Entrá a Decentraland' },
+      desktopText: {
+        [ContentfulLocale.enUS]: richText('Explore worlds, collect wearables and join live events built by the community.'),
+        [ContentfulLocale.es]: richText('Explorá mundos, coleccioná wearables y sumate a los eventos de la comunidad.')
+      },
+      buttonsText: { [ContentfulLocale.enUS]: 'Explore now', [ContentfulLocale.es]: 'Explorar ahora' }
+    }
+  }
+}
+
+const Loading: Story = {
+  args: {
+    isLoading: true
+  }
+}
+
+// The banner renders nothing when the entry failed to load, so consumers can keep the layout untouched.
+const WithError: Story = {
+  args: {
+    fields: null,
+    error: 'Failed to fetch the banner entry'
+  }
+}
+
+// eslint-disable-next-line import/no-default-export
+export default meta
+export { Default, WithoutLogo, WithoutButton, CenteredContent, RightAlignedContent, Localized, Loading, WithError }

--- a/src/config/env/dev.json
+++ b/src/config/env/dev.json
@@ -17,7 +17,7 @@
   "CONTENTFUL_SPACE_ID": "ea2ybdmmn1kv",
   "CONTENTFUL_ENV": "master",
   "CONTENTFUL_NAVBAR_ENTRY_ID": "18g1DzIyBxvu0steSwKyQr",
-  "CONTENTFUL_CONTENTFUL_CDN_URL": "https://cms.decentraland.org",
+  "CONTENTFUL_CONTENTFUL_CDN_URL": "https://cms-api.decentraland.org",
   "MARKETPLACE_NAMES_URL": "https://decentraland.zone/marketplace/names/claim",
   "MARKETPLACE_LANDS_URL": "https://decentraland.zone/marketplace/lands",
   "MARKETPLACE_MY_ASSETS_URL": "https://decentraland.zone/marketplace/account",

--- a/src/config/env/prod.json
+++ b/src/config/env/prod.json
@@ -17,7 +17,7 @@
   "CONTENTFUL_SPACE_ID": "ea2ybdmmn1kv",
   "CONTENTFUL_ENV": "master",
   "CONTENTFUL_NAVBAR_ENTRY_ID": "18g1DzIyBxvu0steSwKyQr",
-  "CONTENTFUL_CONTENTFUL_CDN_URL": "https://cms.decentraland.org",
+  "CONTENTFUL_CONTENTFUL_CDN_URL": "https://cms-api.decentraland.org",
   "MARKETPLACE_NAMES_URL": "https://decentraland.org/marketplace/names/claim",
   "MARKETPLACE_LANDS_URL": "https://decentraland.org/marketplace/lands",
   "MARKETPLACE_MY_ASSETS_URL": "https://decentraland.org/marketplace/account",

--- a/src/config/env/stg.json
+++ b/src/config/env/stg.json
@@ -17,7 +17,7 @@
   "CONTENTFUL_SPACE_ID": "ea2ybdmmn1kv",
   "CONTENTFUL_ENV": "master",
   "CONTENTFUL_NAVBAR_ENTRY_ID": "18g1DzIyBxvu0steSwKyQr",
-  "CONTENTFUL_CONTENTFUL_CDN_URL": "https://cms.decentraland.org",
+  "CONTENTFUL_CONTENTFUL_CDN_URL": "https://cms-api.decentraland.org",
   "MARKETPLACE_NAMES_URL": "https://decentraland.today/marketplace/names/claim",
   "MARKETPLACE_LANDS_URL": "https://decentraland.today/marketplace/lands",
   "MARKETPLACE_MY_ASSETS_URL": "https://decentraland.today/marketplace/account",


### PR DESCRIPTION
Adds Storybook coverage for `Banner`, which was the only Contentful-driven component without stories, and moves the Contentful CDN config to the new host.

**Banner stories** (`Decentraland UI/Banner`): Default, WithoutLogo, WithoutButton, CenteredContent, RightAlignedContent, Localized (es), Loading and WithError. Fields, assets and rich text are mocked locally following the `BannerFields` / `ContentfulAsset` shapes from `@dcl/schemas`, so nothing hits Contentful at runtime. Bundled assets are resolved to absolute URLs because `getAssetUrl` only leaves a url untouched when it already carries a protocol.

**Contentful CDN**: `CONTENTFUL_CONTENTFUL_CDN_URL` now points at `https://cms-api.decentraland.org` in dev, stg and prod.

Verified locally: format, lint, lint:package-json, build and jest all pass, and every story was checked in a local Storybook run.
