### PR TITLE
fix: keep the banner artwork uncropped and the copy off it

### DIFF
--- a/src/components/Banner/Banner.styled.ts
+++ b/src/components/Banner/Banner.styled.ts
@@ -9,28 +9,52 @@ const LoadingContainer = styled(Box)({
   width: '100%'
 })
 
+const BANNER_AREA = 'banner'
+
 const BannerContainer = styled(Box, {
-  shouldForwardProp: prop => prop !== 'background' && prop !== 'aspectRatio'
+  shouldForwardProp: prop => prop !== 'background'
 })<{
   background: string
-  aspectRatio?: number
 }>(props => {
-  const { theme, background, aspectRatio } = props
+  const { background } = props
 
   return {
     width: '100%',
     overflow: 'hidden',
+    // The sizer and the layout share a single grid area, so the row ends up as tall as the taller of
+    // the two: never shorter than the artwork, never shorter than the content.
+    display: 'grid',
+    gridTemplateAreas: `"${BANNER_AREA}"`,
+    backgroundImage: `url(${background})`,
+    backgroundSize: 'cover',
+    backgroundPosition: 'center'
+  }
+})
+
+// The background is painted with `cover`, so a banner shorter than its artwork crops it. This gives the
+// grid row a floor at the artwork's own ratio without ever clipping content that needs more room.
+const BackgroundSizer = styled(Box, {
+  shouldForwardProp: prop => prop !== 'aspectRatio'
+})<{
+  aspectRatio: number
+}>(props => ({
+  gridArea: BANNER_AREA,
+  alignSelf: 'start',
+  width: '100%',
+  aspectRatio: `${props.aspectRatio}`,
+  pointerEvents: 'none'
+}))
+
+const Layout = styled(Box)(props => {
+  const { theme } = props
+
+  return {
+    gridArea: BANNER_AREA,
     display: 'flex',
     padding: '2rem',
     justifyContent: 'space-between',
     flexDirection: 'row',
-    backgroundImage: `url(${background})`,
-    backgroundSize: 'cover',
-    backgroundPosition: 'center',
     alignItems: 'center',
-    // Reserve the artwork's own ratio so `cover` has nothing to crop. `fit-content` keeps taller
-    // content (long copy, a button) from being clipped when it needs more room than the artwork.
-    ...(aspectRatio ? { aspectRatio: `${aspectRatio}`, minHeight: 'fit-content' } : {}),
     [theme.breakpoints.down('sm')]: {
       flexDirection: 'column-reverse'
     }
@@ -123,4 +147,4 @@ const Button = styled(MuiButton)({
   minWidth: '300px'
 })
 
-export { LoadingContainer, BannerContainer, Content, ContentWrapper, Logo, Title, Text, ButtonContainer, Button }
+export { LoadingContainer, BannerContainer, BackgroundSizer, Layout, Content, ContentWrapper, Logo, Title, Text, ButtonContainer, Button }

--- a/src/components/Banner/Banner.styled.ts
+++ b/src/components/Banner/Banner.styled.ts
@@ -10,11 +10,12 @@ const LoadingContainer = styled(Box)({
 })
 
 const BannerContainer = styled(Box, {
-  shouldForwardProp: prop => prop !== 'background'
+  shouldForwardProp: prop => prop !== 'background' && prop !== 'aspectRatio'
 })<{
   background: string
+  aspectRatio?: number
 }>(props => {
-  const { theme, background } = props
+  const { theme, background, aspectRatio } = props
 
   return {
     width: '100%',
@@ -27,6 +28,9 @@ const BannerContainer = styled(Box, {
     backgroundSize: 'cover',
     backgroundPosition: 'center',
     alignItems: 'center',
+    // Reserve the artwork's own ratio so `cover` has nothing to crop. `fit-content` keeps taller
+    // content (long copy, a button) from being clipped when it needs more room than the artwork.
+    ...(aspectRatio ? { aspectRatio: `${aspectRatio}`, minHeight: 'fit-content' } : {}),
     [theme.breakpoints.down('sm')]: {
       flexDirection: 'column-reverse'
     }
@@ -40,13 +44,24 @@ const ContentWrapper = styled(Box)({
   marginRight: '20px'
 })
 
-const Content = styled(Box)(props => {
-  const { theme } = props
+const Content = styled(Box, {
+  shouldForwardProp: prop => prop !== 'constrainedWidth'
+})<{ constrainedWidth?: boolean }>(props => {
+  const { theme, constrainedWidth } = props
 
   return {
     display: 'flex',
     flexDirection: 'column',
     gap: '0.1rem',
+    // Side aligned copy sits next to the subject of the artwork, so keep it in its own half instead of
+    // letting it stretch across the whole banner. Centered copy uses the banner as its canvas.
+    ...(constrainedWidth
+      ? {
+          [theme.breakpoints.up('sm')]: {
+            maxWidth: '50%'
+          }
+        }
+      : {}),
     [theme.breakpoints.down('sm')]: {
       padding: '1rem'
     }

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -5,7 +5,18 @@ import { getAssetAspectRatio, getAssetUrl } from '../../modules/contentful'
 import { useTabletAndBelowMediaQuery } from '../Media'
 import { ContentfulRichText } from './ContentfulRichText'
 import { BannerProps, LowercasedAlignment } from './Banner.types'
-import { BannerContainer, Button, ButtonContainer, Content, LoadingContainer, Logo, Text, Title } from './Banner.styled'
+import {
+  BackgroundSizer,
+  BannerContainer,
+  Button,
+  ButtonContainer,
+  Content,
+  Layout,
+  LoadingContainer,
+  Logo,
+  Text,
+  Title
+} from './Banner.styled'
 import type { Property } from 'csstype'
 
 const convertAlignmentToFlex = (alignment: Property.TextAlign) => {
@@ -41,8 +52,6 @@ export const Banner: React.FC<BannerProps> = (props: BannerProps) => {
   // Build the parameters based on the size of the screen
   const background = isMobileOrTablet ? fields.mobileBackground[ContentfulLocale.enUS] : fields.fullSizeBackground[ContentfulLocale.enUS]
   const bannerBackgroundImage = getAssetUrl(assets, ContentfulLocale.enUS, background)
-  // The background is painted with `cover`, so a banner shorter than the artwork crops it. Letting the
-  // artwork's own ratio drive the height keeps the composition the designer uploaded intact.
   const bannerAspectRatio = getAssetAspectRatio(assets, ContentfulLocale.enUS, background)
   const title = isMobileOrTablet ? fields.mobileTitle[locale] : fields.desktopTitle[locale]
   const titleAlignment = (
@@ -62,25 +71,28 @@ export const Banner: React.FC<BannerProps> = (props: BannerProps) => {
   const isCopyCentered = titleAlignment === 'center' || textAlignment === 'center'
 
   return (
-    <BannerContainer background={bannerBackgroundImage} aspectRatio={bannerAspectRatio}>
-      <Content constrainedWidth={!isCopyCentered}>
-        <Title variant="h1" textAlign={titleAlignment}>
-          {title}
-        </Title>
+    <BannerContainer background={bannerBackgroundImage}>
+      {bannerAspectRatio ? <BackgroundSizer aspectRatio={bannerAspectRatio} /> : null}
+      <Layout>
+        <Content constrainedWidth={!isCopyCentered}>
+          <Title variant="h1" textAlign={titleAlignment}>
+            {title}
+          </Title>
 
-        <Text textAlign={textAlignment}>{text ? <ContentfulRichText document={text} /> : null}</Text>
+          <Text textAlign={textAlignment}>{text ? <ContentfulRichText document={text} /> : null}</Text>
 
-        {fields.showButton[ContentfulLocale.enUS] && fields.buttonLink?.[ContentfulLocale.enUS] && fields.buttonsText?.[locale] ? (
-          <ButtonContainer justifyContent={buttonAlignment}>
-            <Button onClick={onClick} href={fields.buttonLink[ContentfulLocale.enUS]} variant="contained" disableElevation>
-              {fields.buttonsText[locale]}
-            </Button>
-          </ButtonContainer>
-        ) : null}
-      </Content>
-      {fields.logo && fields.logo[ContentfulLocale.enUS] && (
-        <Logo src={getAssetUrl(assets, ContentfulLocale.enUS, fields.logo[ContentfulLocale.enUS])} alt="Banner logo" />
-      )}
+          {fields.showButton[ContentfulLocale.enUS] && fields.buttonLink?.[ContentfulLocale.enUS] && fields.buttonsText?.[locale] ? (
+            <ButtonContainer justifyContent={buttonAlignment}>
+              <Button onClick={onClick} href={fields.buttonLink[ContentfulLocale.enUS]} variant="contained" disableElevation>
+                {fields.buttonsText[locale]}
+              </Button>
+            </ButtonContainer>
+          ) : null}
+        </Content>
+        {fields.logo && fields.logo[ContentfulLocale.enUS] && (
+          <Logo src={getAssetUrl(assets, ContentfulLocale.enUS, fields.logo[ContentfulLocale.enUS])} alt="Banner logo" />
+        )}
+      </Layout>
     </BannerContainer>
   )
 }

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { ContentfulLocale } from '@dcl/schemas'
 import CircularProgress from '@mui/material/CircularProgress'
-import { getAssetUrl } from '../../modules/contentful'
+import { getAssetAspectRatio, getAssetUrl } from '../../modules/contentful'
 import { useTabletAndBelowMediaQuery } from '../Media'
 import { ContentfulRichText } from './ContentfulRichText'
 import { BannerProps, LowercasedAlignment } from './Banner.types'
@@ -39,11 +39,11 @@ export const Banner: React.FC<BannerProps> = (props: BannerProps) => {
   }
 
   // Build the parameters based on the size of the screen
-  const bannerBackgroundImage = getAssetUrl(
-    assets,
-    ContentfulLocale.enUS,
-    isMobileOrTablet ? fields.mobileBackground[ContentfulLocale.enUS] : fields.fullSizeBackground[ContentfulLocale.enUS]
-  )
+  const background = isMobileOrTablet ? fields.mobileBackground[ContentfulLocale.enUS] : fields.fullSizeBackground[ContentfulLocale.enUS]
+  const bannerBackgroundImage = getAssetUrl(assets, ContentfulLocale.enUS, background)
+  // The background is painted with `cover`, so a banner shorter than the artwork crops it. Letting the
+  // artwork's own ratio drive the height keeps the composition the designer uploaded intact.
+  const bannerAspectRatio = getAssetAspectRatio(assets, ContentfulLocale.enUS, background)
   const title = isMobileOrTablet ? fields.mobileTitle[locale] : fields.desktopTitle[locale]
   const titleAlignment = (
     isMobileOrTablet ? fields.mobileTitleAlignment[ContentfulLocale.enUS] : fields.desktopTitleAlignment[ContentfulLocale.enUS]
@@ -59,9 +59,11 @@ export const Banner: React.FC<BannerProps> = (props: BannerProps) => {
     )?.toLowerCase() as LowercasedAlignment
   )
 
+  const isCopyCentered = titleAlignment === 'center' || textAlignment === 'center'
+
   return (
-    <BannerContainer background={bannerBackgroundImage}>
-      <Content>
+    <BannerContainer background={bannerBackgroundImage} aspectRatio={bannerAspectRatio}>
+      <Content constrainedWidth={!isCopyCentered}>
         <Title variant="h1" textAlign={titleAlignment}>
           {title}
         </Title>

--- a/src/modules/contentful.spec.ts
+++ b/src/modules/contentful.spec.ts
@@ -1,0 +1,59 @@
+import { ContentfulAsset, ContentfulLocale, SysLink } from '@dcl/schemas'
+import { getAssetAspectRatio } from './contentful'
+
+const ASSET_ID = 'asset-id'
+
+const assetLink: SysLink<'Asset'> = {
+  sys: { type: 'Link', linkType: 'Asset', id: ASSET_ID }
+}
+
+const buildAsset = (file: Record<string, unknown>): ContentfulAsset =>
+  ({
+    metadata: { tags: [], concepts: [] },
+    sys: { id: ASSET_ID, type: 'Asset' },
+    fields: {
+      title: { [ContentfulLocale.enUS]: 'title' },
+      description: { [ContentfulLocale.enUS]: '' },
+      file: { [ContentfulLocale.enUS]: file }
+    }
+  }) as unknown as ContentfulAsset
+
+const buildAssets = (file: Record<string, unknown>): Record<string, ContentfulAsset> => ({
+  [ASSET_ID]: buildAsset(file)
+})
+
+describe('getAssetAspectRatio', () => {
+  it('should return undefined when the asset link is not defined', () => {
+    expect(getAssetAspectRatio(buildAssets({ details: { image: { width: 1920, height: 300 } } }), ContentfulLocale.enUS)).toBeUndefined()
+  })
+
+  it('should return undefined when the asset is missing from the assets map', () => {
+    expect(getAssetAspectRatio({}, ContentfulLocale.enUS, assetLink)).toBeUndefined()
+  })
+
+  it('should return undefined when the asset has no details', () => {
+    expect(getAssetAspectRatio(buildAssets({ url: 'https://an.url/image.jpg' }), ContentfulLocale.enUS, assetLink)).toBeUndefined()
+  })
+
+  it('should return undefined when the details have no image dimensions', () => {
+    expect(getAssetAspectRatio(buildAssets({ details: { size: 100 } }), ContentfulLocale.enUS, assetLink)).toBeUndefined()
+  })
+
+  it('should return undefined when a dimension is zero', () => {
+    expect(
+      getAssetAspectRatio(buildAssets({ details: { image: { width: 1920, height: 0 } } }), ContentfulLocale.enUS, assetLink)
+    ).toBeUndefined()
+  })
+
+  it('should return undefined when the requested locale has no file', () => {
+    expect(
+      getAssetAspectRatio(buildAssets({ details: { image: { width: 1920, height: 300 } } }), ContentfulLocale.es, assetLink)
+    ).toBeUndefined()
+  })
+
+  it('should return the ratio between the width and the height of the image', () => {
+    expect(getAssetAspectRatio(buildAssets({ details: { image: { width: 1920, height: 300 } } }), ContentfulLocale.enUS, assetLink)).toBe(
+      6.4
+    )
+  })
+})

--- a/src/modules/contentful.ts
+++ b/src/modules/contentful.ts
@@ -9,4 +9,15 @@ const getAssetUrl = (assets: Record<string, ContentfulAsset>, locale: Contentful
   return ''
 }
 
-export { getAssetUrl }
+const getAssetAspectRatio = (
+  assets: Record<string, ContentfulAsset>,
+  locale: ContentfulLocale,
+  assetLink?: SysLink<'Asset'>
+): number | undefined => {
+  if (!assetLink) return undefined
+  const image = assets[assetLink.sys.id]?.fields.file[locale]?.details?.image
+  if (!image?.width || !image?.height) return undefined
+  return image.width / image.height
+}
+
+export { getAssetUrl, getAssetAspectRatio }


### PR DESCRIPTION
The `Banner` background is painted with `background-size: cover` and nothing reserved the artwork's own height, so the container was always as tall as its copy. A campaign banner whose desktop artwork is a 1920x300 hero ended up in a 117px tall box: `cover` scaled the image to 226px and cropped 109px of it (48% of the art), and the single line of desktop copy stretched across the full width, running over the subject of the artwork.

### What changed

- `getAssetAspectRatio` reads the real `details.image` dimensions that Contentful already returns for every image asset.
- The container is now a single cell grid holding two layers: a zero content `BackgroundSizer` carrying the artwork's aspect ratio, and the `Layout` that holds the copy and the logo. The row ends up as tall as the taller layer, so the banner is never shorter than the artwork and never shorter than its own content.
- Side aligned copy is kept to its own half of the banner on tablet and up, since that half is what the artwork leaves free. Centered copy still spans the full width and stays centered.

Assets without image dimensions (SVGs, hand built fixtures) render with no sizer and keep the previous content driven height, so this is additive for anything the CMS cannot measure.

The first attempt used `aspect-ratio` plus `min-height: fit-content` on the container. Chrome does not clamp with block axis intrinsic keywords there (`max-content` behaves the same), so once the copy needed more room than the artwork the button was cut off by the container's `overflow: hidden`. The grid version is what actually holds both bounds.

### Verification

Ran against the marketplace homepage banner (`marketplaceHomepageBanner`, desktop art 1920x300, mobile art 400x400) with this branch linked into a local marketplace, plus the existing stories.

Desktop, sweeping the width of the column the banner sits in:

| container | banner | artwork ratio height | result |
| --- | --- | --- | --- |
| 1400px | 1352x211 | 211px | matches the artwork ratio exactly |
| 1200px | 1152x223 | 180px | grew for the content, nothing clipped |
| 900px | 852x250 | 133px | grew for the content, nothing clipped |
| 700px | 652x277 | 102px | grew for the content, nothing clipped |

- Before the fix the same banner was 1449x117 with the art cropped in half and the copy over the avatars.
- Mobile 390px: 390x390, matching the square mobile art, copy and CTA below it, nothing clipped.
- With the CTA forced on (the CMS entry currently has `showButton: false`) the button renders inside the banner at every width above.
- `Default`, `WithoutLogo`, `WithoutButton` and `CenteredContent` stories render unchanged: their fixtures declare no image dimensions, and the centered story keeps its full width copy.
- `npm run lint`, `npm run lint:package-json`, `npm test` (44 tests, 7 new for the helper) and `npm run build` all pass.
